### PR TITLE
modbus-serial: fixed crc and response handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "url": "https://github.com/Cloud-Automation/node-modbus"
   },
   "dependencies": {
+    "crc": "^3.4.0",
     "put": "0.0.6",
     "q": "1.0.1",
     "serialport": "^3.0.0",

--- a/src/modbus-serial-client.js
+++ b/src/modbus-serial-client.js
@@ -19,11 +19,9 @@ module.exports = stampit()
             if (!this.portName) { throw new Error('No portname.' );}
             if (!this.baudRate) { this.baudRate = 115200; }
             
-            this.baudRate = 115200;
-
             serialport = new SerialPort(this.portName, {
                 baudRate : this.baudrate,
-                parity : 'even'
+                parity : 'none'
             });
 
             serialport.on('open', onOpen);

--- a/src/modbus-serial-client.js
+++ b/src/modbus-serial-client.js
@@ -2,6 +2,8 @@ var stampit         = require('stampit'),
     Put             = require('put'),
     ModbusCore      = require('./modbus-client-core.js');
 
+var crc16modbus = require('crc').crc16modbus;
+
 module.exports = stampit()
     .compose(ModbusCore)
     .init(function () {
@@ -49,8 +51,8 @@ module.exports = stampit()
         var onData = function (pdu) {
         
             this.log.debug('received data');
-
-            this.emit('data', pdu);             
+            // Compared to ModBus TCP, ModBus RTU adds the device address which we need to remove
+            this.emit('data', pdu.slice(1));
         
         }.bind(this);
 
@@ -62,18 +64,16 @@ module.exports = stampit()
     
         var onSend = function (pdu) {
 
+            // TODO: slave address is now hard-coded to 1
             var pkt = Put()
                 .word8(1)
                 .put(pdu),
                 buf = pkt.buffer();
-                crc = 0;
 
+            var crc = crc16modbus(buf);
 
-            for (var i = 0; i < buf.length; i += 1) {
-                crc = (buf.readUInt8(i) + crc) % 0xFFFF; 
-            }
-               
-            pkt = pkt.word16be(crc).buffer(); 
+            // Add CRC in little-endian mode (least significant byte first)
+            pkt = pkt.word16le(crc).buffer();
 
             for (var j = 0; j < pkt.length; j += 1) {
                 console.log(pkt.readUInt8(j).toString(16));


### PR DESCRIPTION
the current (probably untested) serial implementation calculates a basic
checksum instead of the required CRC-16 in Modbus mode.
Also, the reponse handlers do not expect buffers the slave address as
the first byte, which therefore needs to be removed.
Fixed both.