### PR TITLE
Correct ReadCoils behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,33 +44,40 @@ client.on('connect', function () {
 
     client.readCoils(0, 13).then(function (resp) {
 
-        // resp will look like { fc: 1, byteCount: 20, coils: [ values 0 - 13 ] } 
+        // resp will look like { fc: 1, byteCount: 20, coils: [ values 0 - 13 ], payload: <Buffer> } 
         console.log(resp);
 
     }).fail(console.log);
 
     client.readDiscreteInputs(0, 13).then(function (resp) {
 
-        // resp will look like { fc: 2, byteCount: 20, coils: [ values 0 - 13 ] } 
+        // resp will look like { fc: 2, byteCount: 20, coils: [ values 0 - 13 ], payload: <Buffer> } 
         console.log(resp);
 
     }).fail(console.log);
 
     client.readHoldingRegisters(0, 10).then(function (resp) {
 
-        // resp will look like { fc: 3, byteCount: 20, register: [ values 0 - 10 ] }
+        // resp will look like { fc: 3, byteCount: 20, register: [ values 0 - 10 ], payload: <Buffer> }
         console.log(resp); 
 
     }).fail(console.log);
 
     client.readInputRegisters(0, 10).then(function (resp) {
 
-	    // resp will look like { fc: 4, byteCount: 20, register: [ values 0 - 10 ] }
+	    // resp will look like { fc: 4, byteCount: 20, register: [ values 0 - 10 ], payload: <Buffer> }
 	    console.log(resp);
 
     }).fail(console.log);
 
     client.writeSingleCoil(5, true).then(function (resp) {
+
+	    // resp will look like { fc: 5, byteCount: 4, outputAddress: 5, outputValue: true }
+	    console.log(resp);
+
+    }).fail(console.log);
+
+    client.writeSingleCoil(5, new Buffer(0x01)).then(function (resp) {
 
 	    // resp will look like { fc: 5, byteCount: 4, outputAddress: 5, outputValue: true }
 	    console.log(resp);
@@ -84,6 +91,13 @@ client.on('connect', function () {
 
     }).fail(console.log);
 
+    client.writeSingleRegister(13, new Buffer([0x00 0x2A])).then(function (resp) {
+
+	    // resp will look like { fc: 6, byteCount: 4, registerAddress: 13, registerValue: 42 }
+	    console.log(resp);
+
+    }).fail(console.log);
+
     client.writeMultipleCoils(3, [1, 0, 1, 0, 1, 1]).then(function (resp) {
 
         // resp will look like { fc: 15, startAddress: 3, quantity: 6 }
@@ -91,7 +105,21 @@ client.on('connect', function () {
 
     }).fail(console.log);
 
+    client.writeMultipleCoils(3, new Buffer([0x2B]), 6).then(function (resp) {
+
+        // resp will look like { fc: 15, startAddress: 3, quantity: 6 }
+        console.log(resp); 
+
+    }).fail(console.log);
+
     client.writeMultipleRegisters(4, [1, 2, 3, 4]).then(function (resp) {
+        
+        // resp will look like { fc : 16, startAddress: 4, quantity: 4 }
+        console.log(resp);
+        
+    }).fail(console.log);
+
+    client.writeMultipleRegisters(4, new Buffer([0x00, 0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04]).then(function (resp) {
         
         // resp will look like { fc : 16, startAddress: 4, quantity: 4 }
         console.log(resp);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "description": "Implementation for the Serial/TCP Modbus protocol.",
   "author": "Stefan Poeter <stefan.poeter@cloud-automation.de>",
   "main": "./src/modbus.js",

--- a/src/handler/client/ReadCoils.js
+++ b/src/handler/client/ReadCoils.js
@@ -23,6 +23,7 @@ module.exports = Stampit()
             var resp = {
                     fc          : fc,
                     byteCount   : byteCount,
+                    payload     : pdu.slice(2),
                     coils       : [] 
                 };
 

--- a/src/handler/client/ReadDiscreteInputs.js
+++ b/src/handler/client/ReadDiscreteInputs.js
@@ -22,6 +22,7 @@ module.exports = Stampit()
                 resp        = {
                     fc          : fc,
                     byteCount   : byteCount,
+                    payload     : pdu.slice(2),
                     coils       : []
                 };
 

--- a/src/handler/client/ReadHoldingRegisters.js
+++ b/src/handler/client/ReadHoldingRegisters.js
@@ -22,6 +22,7 @@ module.exports = Stampit()
             var resp = {
                 fc          : fc,
                 byteCount   : byteCount,
+                payload     : pdu.slice(2),
                 register    : [ ]
             };
 

--- a/src/handler/client/ReadInputRegisters.js
+++ b/src/handler/client/ReadInputRegisters.js
@@ -22,6 +22,7 @@ module.exports = Stampit()
             var resp = {
                 fc          : fc,
                 byteCount   : byteCount,
+                payload     : pdu.slice(2),
                 register    : []
             };
 

--- a/src/handler/client/WriteSingleCoil.js
+++ b/src/handler/client/WriteSingleCoil.js
@@ -38,7 +38,8 @@ module.exports = Stampit()
  
             var fc      = 5,
                 defer   = Q.defer(), 
-                pdu     = Put().word8be(5).word16be(address).word16be(value?0xff00:0x0000).buffer();
+                payload = (value instanceof Buffer) ? (value.readUInt8(0) > 0) : value,
+                pdu     = Put().word8be(5).word16be(address).word16be(payload?0xff00:0x0000).buffer();
 
             this.queueRequest(fc, pdu, defer);
 

--- a/src/handler/client/WriteSingleRegister.js
+++ b/src/handler/client/WriteSingleRegister.js
@@ -23,7 +23,9 @@ module.exports = Stampit()
             var resp = {
                 fc              : fc,
                 registerAddress : registerAddress,
-                registerValue   : registerValue
+                registerValue   : registerValue,
+                registerValueRaw: pdu.slice(1,2),
+                registerValueRaw: pdu.slice(3,2)
             };
 
             if (fc !== 6) {
@@ -39,7 +41,8 @@ module.exports = Stampit()
  
             var fc      = 6,
                 defer   = Q.defer(),
-                pdu     = Put().word8be(6).word16be(address).word16be(value).buffer();
+                payload = (value instanceof Buffer) ? value : Put().word16be(value).buffer(),
+                pdu     = Put().word8be(6).word16be(address).put(payload).buffer();
 
             this.queueRequest(fc, pdu, defer);
 

--- a/src/handler/server/ReadCoils.js
+++ b/src/handler/server/ReadCoils.js
@@ -47,23 +47,25 @@ module.exports = stampit()
                 }
 
                 var val = 0, 
-                    j = 0,
+                    thisByteBitCount = 0,
                     response = Put().word8(0x01).word8(Math.floor(quantity / 8) + (quantity % 8 === 0 ? 0 : 1));
 
-                for (var i = start; i < start + quantity; i += 1) {
+                for (var totalBitCount = start; totalBitCount < start + quantity; totalBitCount += 1) {
      
-                    val += mem.readUInt8(Math.floor(i / 8)) &  Math.pow(2, i % 8);
-               
-                    j += 1;
+                    var buf = mem.readUInt8(Math.floor(totalBitCount / 8))
+                    var mask = 1 << (totalBitCount % 8)
 
-                    if (j % 8 === 0 || i === (start + quantity) - 1) {
+                    if(buf & mask) {
+                      val += 1 << (thisByteBitCount % 8)
+                    }
+               
+                    thisByteBitCount += 1;
+
+                    if (thisByteBitCount % 8 === 0 || totalBitCount === (start + quantity) - 1) {
                    
                         response.word8(val);
                         val = 0;
-                    
                     }
-
-
                 }
 
                 cb(response.buffer());

--- a/src/handler/server/ReadDiscreteInputs.js
+++ b/src/handler/server/ReadDiscreteInputs.js
@@ -47,23 +47,25 @@ var handler = stampit()
                 }
 
                 var val = 0, 
-                    j = 0,
+                    thisByteBitCount = 0,
                     response = Put().word8(0x02).word8(Math.floor(quantity / 8) + (quantity % 8 === 0 ? 0 : 1));
 
-                for (var i = start; i < start + quantity; i += 1) {
+                for (var totalBitCount = start; totalBitCount < start + quantity; totalBitCount += 1) {
      
-                    val += mem.readUInt8(Math.floor(i / 8)) &  Math.pow(2, i % 8);
-               
-                    j += 1;
+                    var buf = mem.readUInt8(Math.floor(totalBitCount / 8))
+                    var mask = 1 << (totalBitCount % 8)
 
-                    if (j % 8 === 0 || i === (start + quantity) - 1) {
+                    if(buf & mask) {
+                      val += 1 << (thisByteBitCount % 8)
+                    }
+               
+                    thisByteBitCount += 1;
+
+                    if (thisByteBitCount % 8 === 0 || totalBitCount === (start + quantity) - 1) {
                    
                         response.word8(val);
                         val = 0;
-                    
                     }
-
-
                 }
 
                 cb(response.buffer());

--- a/src/modbus-client-core.js
+++ b/src/modbus-client-core.js
@@ -24,9 +24,10 @@ module.exports = stampit()
     .compose(Log)
     .init(function () {
 
-        var reqFifo         = [],
-            responseHandler = { },
+        var responseHandler = { },
             currentRequest  = null;
+
+        this.reqFifo = [];
    
         var init = function () {
       
@@ -45,12 +46,12 @@ module.exports = stampit()
             this.log.debug('Trying to flush data.');
 
 
-            if (reqFifo.length === 0) {
+            if (this.reqFifo.length === 0) {
                 this.log.debug('Nothing in request pipe.');
                 return;
             }
 
-            currentRequest = reqFifo.shift();
+            currentRequest = this.reqFifo.shift();
 
             currentRequest.timeout = setTimeout(function () {
 
@@ -80,8 +81,8 @@ module.exports = stampit()
             }
 
             this.log.debug('Cleaning up request fifo.');
-            reqFifo.forEach(function () {
-                reqFifo.pop();
+            this.reqFifo.forEach(function () {
+                this.reqFifo.pop();
             });
             
         
@@ -170,7 +171,7 @@ module.exports = stampit()
                 pdu: pdu
             };
 
-            reqFifo.push(req);
+            this.reqFifo.push(req);
 
             if (this.inState('ready')) {
                 flush();

--- a/src/modbus-tcp-server.js
+++ b/src/modbus-tcp-server.js
@@ -10,6 +10,7 @@ module.exports = stampit()
     .init(function () {
     
         var server, socketCount = 0, fifo = [];
+        var clients = []
 
         var init = function () {
        
@@ -27,6 +28,7 @@ module.exports = stampit()
 
                 this.log.debug('new connection', s.address());
  
+                clients.push(s)
                 initiateSocket(s);
            
             }.bind(this));
@@ -149,7 +151,14 @@ module.exports = stampit()
 
         this.close = function (cb) {
         
-            server.close(cb);
+          for(var c in clients) {
+            clients[c].destroy()
+          }
+
+          server.close(function() {
+            server.unref() 
+            if(cb) { cb() } 
+          });
         
         };
 

--- a/test/modbus-client-inspector.js
+++ b/test/modbus-client-inspector.js
@@ -1,0 +1,9 @@
+var stampit = require('stampit')
+
+module.exports = stampit()
+  .init(function () {
+
+    this.queueSpy = function () {
+      return this.reqFifo[this.reqFifo.length - 1]
+    }
+  })

--- a/test/modbus-server-core.test.js
+++ b/test/modbus-server-core.test.js
@@ -41,7 +41,27 @@ describe("Modbus Server Core Tests.", function () {
             var core        = Core(),
                 request     = Put().word8(0x01).word16be(0).word16be(5).buffer(),
                 exResponse  = Put().word8(0x01).word8(1).word8(0x15).buffer();         
-     
+
+            core.getCoils().writeUInt8(0x15, 0); 
+
+            var resp = function (response) {
+           
+                assert.equal(response.compare(exResponse), 0);
+
+                done();
+
+            };
+
+            core.onData(request, resp);
+                    
+        });
+
+        it('should handle a read coils request with odd start address just fine.', function (done) {
+
+            var core        = Core(),
+                request     = Put().word8(0x01).word16be(2).word16be(5).buffer(),
+                exResponse  = Put().word8(0x01).word8(1).word8(0x05).buffer();         
+
             core.getCoils().writeUInt8(0x15, 0); 
 
             var resp = function (response) {
@@ -104,6 +124,26 @@ describe("Modbus Server Core Tests.", function () {
             var core        = Core(),
                 request     = Put().word8(0x02).word16be(0).word16be(5).buffer(),
                 exResponse  = Put().word8(0x02).word8(1).word8(0x15).buffer();         
+     
+            core.getInput().writeUInt8(0x15, 0); 
+
+            var resp = function (response) {
+           
+                assert.equal(response.compare(exResponse), 0);
+
+                done();
+
+            };
+
+            core.onData(request, resp);
+                    
+        });
+
+        it('should handle a read discrete inputs request with odd start address just fine.', function (done) {
+
+            var core        = Core(),
+                request     = Put().word8(0x02).word16be(2).word16be(5).buffer(),
+                exResponse  = Put().word8(0x02).word8(1).word8(0x05).buffer();         
      
             core.getInput().writeUInt8(0x15, 0); 
 


### PR DESCRIPTION
As described in #44 the functions `ReadCoils` and `ReadDiscreteInputs` did not work according to the spec in the server implementation.

Additionally, I added the passing of the raw data buffer in the response, because it allows easier interpretation of the result, e.g. in situations where the register value is not encoded as uint16be

