### PR TITLE
fixed fifo clean up

### DIFF
--- a/src/modbus-client-core.js
+++ b/src/modbus-client-core.js
@@ -81,9 +81,7 @@ module.exports = stampit()
             }
 
             this.log.debug('Cleaning up request fifo.');
-            this.reqFifo.forEach(function () {
-                this.reqFifo.pop();
-            });
+            this.reqFifo = [];
             
         
         }.bind(this);


### PR DESCRIPTION
The existing implementation led to an undefined behavior during tests with multiple modbus connections. 
Due to the asynchronous the fifo doesn't exist anymore, when the pop is executed, which results to the following error:
`Uncaught TypeError: Cannot read property 'pop' of undefined
      at node_modules/jsmodbus/src/modbus-client-core.js:85:29
      at Array.forEach (native)
      at Object.<anonymous> (node_modules/jsmodbus/src/modbus-client-core.js:86:26)
      at Object.emit (node_modules/stampit-event-bus/src/stampit-event-bus.js:20:38)
      at Object.setState (node_modules/stampit-state-machine/src/stampit-state-machine.js:23:14)
      at Object.<anonymous> (node_modules/jsmodbus/src/modbus-tcp-client.js:67:18)
      at TCP._onclose (net.js:484:12)`

My simple fix is solves this problem and should be even more performant.

Best,
Michael