### PR TITLE
Update modbus-serial-client.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "put": "0.0.6",
     "q": "1.0.1",
+    "crc": "3.4.0",
     "serialport": "^4.0.1",
     "stampit": "^2.1.2",
     "stampit-event-bus": "^0.1.1",

--- a/src/modbus-serial-client.js
+++ b/src/modbus-serial-client.js
@@ -71,7 +71,9 @@ module.exports = stampit()
         var onData = function (pdu) {
         
             this.log.debug('received data');
-            this.emit('data', pdu.slice(1));
+            if( crc.crc16modbus(pdu) === 0 ) { /* PDU is valid if CRC across whole PDU equals 0, else ignore and do nothing */
+              this.emit('data', pdu.slice(1));
+            }
         
         }.bind(this);
 


### PR DESCRIPTION
1. onData() function returns to the emitter now the PDU without the first PDU byte which is the mirrored Modbus slave address in a slaves response
2. The onSend() function no longer sends to Modbus Slave address #1 constantly, but to specified UnitID known from Modbus TCP
3. Instead of building the PDU checksum by simple addition, now the checksum is built by CRC generator