### PR TITLE
Performance tweaks

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "url": "https://github.com/Cloud-Automation/node-modbus"
   },
   "dependencies": {
+    "bluebird": "^3.4.6",
     "put": "0.0.6",
-    "q": "1.0.1",
     "crc": "3.4.0",
     "serialport": "^4.0.1",
     "stampit": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Implementation for the Serial/TCP Modbus protocol.",
   "author": "Stefan Poeter <stefan.poeter@cloud-automation.de>",
   "main": "./src/modbus.js",
@@ -10,7 +10,6 @@
   },
   "dependencies": {
     "bluebird": "^3.4.6",
-    "put": "0.0.6",
     "crc": "3.4.0",
     "serialport": "^4.0.1",
     "stampit": "^2.1.2",

--- a/src/handler/client/ReadCoils.js
+++ b/src/handler/client/ReadCoils.js
@@ -1,5 +1,5 @@
 var Stampit = require('stampit'),
-    Q       = require('q'),
+    Promise = require('bluebird'),
     Put     = require('put');
 
 
@@ -50,7 +50,7 @@ module.exports = Stampit()
         this.readCoils = function (start, quantity) {
  
             var fc      = 1,
-                defer   = Q.defer(),
+                defer   = Promise.defer(),
                 pdu     = Put().word8(fc).word16be(start).word16be(quantity).buffer();
 
             this.queueRequest(fc, pdu, defer);

--- a/src/handler/client/ReadCoils.js
+++ b/src/handler/client/ReadCoils.js
@@ -1,7 +1,5 @@
 var Stampit = require('stampit'),
-    Promise = require('bluebird'),
-    Put     = require('put');
-
+    Promise = require('bluebird')
 
 module.exports = Stampit()
     .init(function () {
@@ -51,7 +49,11 @@ module.exports = Stampit()
  
             var fc      = 1,
                 defer   = Promise.defer(),
-                pdu     = Put().word8(fc).word16be(start).word16be(quantity).buffer();
+                pdu     = Buffer.allocUnsafe(5)
+
+            pdu.writeUInt8(fc,0)
+            pdu.writeUInt16BE(start,1)
+            pdu.writeUInt16BE(quantity,3)
 
             this.queueRequest(fc, pdu, defer);
             

--- a/src/handler/client/ReadDiscreteInputs.js
+++ b/src/handler/client/ReadDiscreteInputs.js
@@ -1,7 +1,5 @@
 var Stampit = require('stampit'),
-    Promise = require('bluebird'),
-    Put     = require('put');
-
+    Promise = require('bluebird')
 
 module.exports = Stampit()
     .init(function () {
@@ -48,15 +46,16 @@ module.exports = Stampit()
  
             var fc      = 2,
                 defer   = Promise.defer(),
-                pdu     = Put().word8be(2).word16be(start).word16be(quantity).buffer();
+                pdu     = Buffer.allocUnsafe(5)
+
+            pdu.writeUInt8(fc)
+            pdu.writeUInt16BE(start,1)
+            pdu.writeUInt16BE(quantity,3)
 
             if (quantity > 2000) {    
 
                 defer.reject(); 
-         
                 return defer.promise; 
-                
-
             }
 
             this.queueRequest(fc, pdu, defer);

--- a/src/handler/client/ReadDiscreteInputs.js
+++ b/src/handler/client/ReadDiscreteInputs.js
@@ -1,5 +1,5 @@
 var Stampit = require('stampit'),
-    Q       = require('q'),
+    Promise = require('bluebird'),
     Put     = require('put');
 
 
@@ -47,7 +47,7 @@ module.exports = Stampit()
         this.readDiscreteInputs = function (start, quantity) {
  
             var fc      = 2,
-                defer   = Q.defer(),
+                defer   = Promise.defer(),
                 pdu     = Put().word8be(2).word16be(start).word16be(quantity).buffer();
 
             if (quantity > 2000) {    

--- a/src/handler/client/ReadHoldingRegisters.js
+++ b/src/handler/client/ReadHoldingRegisters.js
@@ -1,7 +1,5 @@
 var Stampit = require('stampit'),
-    Promise = require('bluebird'),
-    Put     = require('put');
-
+    Promise = require('bluebird')
 
 module.exports = Stampit()
     .init(function () {
@@ -48,7 +46,11 @@ module.exports = Stampit()
 
             var fc      = 3,
                 defer   = Promise.defer(),
-                pdu     = Put().word8be(3).word16be(start).word16be(quantity).buffer();
+                pdu     = Buffer.allocUnsafe(5)
+
+            pdu.writeUInt8(fc)
+            pdu.writeUInt16BE(start,1)
+            pdu.writeUInt16BE(quantity,3)
 
             this.queueRequest(fc, pdu, defer);
 

--- a/src/handler/client/ReadHoldingRegisters.js
+++ b/src/handler/client/ReadHoldingRegisters.js
@@ -1,5 +1,5 @@
 var Stampit = require('stampit'),
-    Q       = require('q'),
+    Promise = require('bluebird'),
     Put     = require('put');
 
 
@@ -47,7 +47,7 @@ module.exports = Stampit()
            this.log.debug('Starting read holding registers request.'); 
 
             var fc      = 3,
-                defer   = Q.defer(),
+                defer   = Promise.defer(),
                 pdu     = Put().word8be(3).word16be(start).word16be(quantity).buffer();
 
             this.queueRequest(fc, pdu, defer);

--- a/src/handler/client/ReadInputRegisters.js
+++ b/src/handler/client/ReadInputRegisters.js
@@ -1,5 +1,5 @@
 var Stampit = require('stampit'),
-    Q       = require('q'),
+    Promise = require('bluebird'),
     Put     = require('put');
 
 
@@ -45,7 +45,7 @@ module.exports = Stampit()
         this.readInputRegisters = function (start, quantity) {
  
             var fc      = 4, 
-                defer   = Q.defer(),
+                defer   = Promise.defer(),
                 pdu     = Put().word8be(4).word16be(start).word16be(quantity).buffer();
 
             this.queueRequest(fc, pdu, defer);

--- a/src/handler/client/ReadInputRegisters.js
+++ b/src/handler/client/ReadInputRegisters.js
@@ -1,7 +1,5 @@
 var Stampit = require('stampit'),
-    Promise = require('bluebird'),
-    Put     = require('put');
-
+    Promise = require('bluebird')
 
 module.exports = Stampit()
     .init(function () {
@@ -46,7 +44,11 @@ module.exports = Stampit()
  
             var fc      = 4, 
                 defer   = Promise.defer(),
-                pdu     = Put().word8be(4).word16be(start).word16be(quantity).buffer();
+                pdu     = Buffer.allocUnsafe(5)
+
+            pdu.writeUInt8(fc)
+            pdu.writeUInt16BE(start,1)
+            pdu.writeUInt16BE(quantity,3)
 
             this.queueRequest(fc, pdu, defer);
 

--- a/src/handler/client/WriteMultipleCoils.js
+++ b/src/handler/client/WriteMultipleCoils.js
@@ -1,5 +1,5 @@
 var stampit = require('stampit'),
-    Q       = require('q'),
+    Promise = require('bluebird'),
     Put     = require('put');
 
 
@@ -38,7 +38,7 @@ module.exports = stampit()
 
         this.writeMultipleCoils = function (startAddress, coils, N) {
  
-            var defer = Q.defer();
+            var defer = Promise.defer();
             var fc          = 15,
                 pdu         = Put()
                                 .word8(fc)

--- a/src/handler/client/WriteMultipleRegisters.js
+++ b/src/handler/client/WriteMultipleRegisters.js
@@ -1,5 +1,5 @@
 var stampit = require('stampit'),
-    Q       = require('q'),
+    Promise = require('bluebird'),
     Put     = require('put');
 
 
@@ -38,7 +38,7 @@ module.exports = stampit()
 
         this.writeMultipleRegisters = function (startAddress, register) {
  
-            var defer = Q.defer();
+            var defer = Promise.defer();
             var fc          = 16,
                 pdu         = Put()
                                 .word8(fc)

--- a/src/handler/client/WriteSingleCoil.js
+++ b/src/handler/client/WriteSingleCoil.js
@@ -1,6 +1,5 @@
 var Stampit = require('stampit'),
-    Promise = require('bluebird'),
-    Put     = require('put');
+    Promise = require('bluebird')
 
 module.exports = Stampit()
     .init(function () {
@@ -39,7 +38,11 @@ module.exports = Stampit()
             var fc      = 5,
                 defer   = Promise.defer(), 
                 payload = (value instanceof Buffer) ? (value.readUInt8(0) > 0) : value,
-                pdu     = Put().word8be(5).word16be(address).word16be(payload?0xff00:0x0000).buffer();
+                pdu     = Buffer.allocUnsafe(5)
+            
+            pdu.writeUInt8(fc,0)
+            pdu.writeUInt16BE(address,1)
+            pdu.writeUInt16BE(payload ? 0xff00:0x0000,3)
 
             this.queueRequest(fc, pdu, defer);
 

--- a/src/handler/client/WriteSingleCoil.js
+++ b/src/handler/client/WriteSingleCoil.js
@@ -1,5 +1,5 @@
 var Stampit = require('stampit'),
-    Q       = require('q'),
+    Promise = require('bluebird'),
     Put     = require('put');
 
 module.exports = Stampit()
@@ -37,7 +37,7 @@ module.exports = Stampit()
         this.writeSingleCoil = function (address, value) {
  
             var fc      = 5,
-                defer   = Q.defer(), 
+                defer   = Promise.defer(), 
                 payload = (value instanceof Buffer) ? (value.readUInt8(0) > 0) : value,
                 pdu     = Put().word8be(5).word16be(address).word16be(payload?0xff00:0x0000).buffer();
 

--- a/src/handler/client/WriteSingleRegister.js
+++ b/src/handler/client/WriteSingleRegister.js
@@ -1,7 +1,5 @@
 var Stampit = require('stampit'),
-    Promise = require('bluebird'),
-    Put     = require('put');
-
+    Promise = require('bluebird')
 
 module.exports = Stampit()
     .init(function () {
@@ -41,8 +39,12 @@ module.exports = Stampit()
  
             var fc      = 6,
                 defer   = Promise.defer(),
-                payload = (value instanceof Buffer) ? value : Put().word16be(value).buffer(),
-                pdu     = Put().word8be(6).word16be(address).put(payload).buffer();
+                payload = (value instanceof Buffer) ? value.readUInt16BE(0) : value,
+                pdu     = Buffer.allocUnsafe(5)
+
+            pdu.writeUInt8(fc, 0)
+            pdu.writeUInt16BE(address, 1)
+            pdu.writeUInt16BE(payload, 3)
 
             this.queueRequest(fc, pdu, defer);
 

--- a/src/handler/client/WriteSingleRegister.js
+++ b/src/handler/client/WriteSingleRegister.js
@@ -1,5 +1,5 @@
 var Stampit = require('stampit'),
-    Q       = require('q'),
+    Promise = require('bluebird'),
     Put     = require('put');
 
 
@@ -40,7 +40,7 @@ module.exports = Stampit()
         this.writeSingleRegister = function (address, value) {
  
             var fc      = 6,
-                defer   = Q.defer(),
+                defer   = Promise.defer(),
                 payload = (value instanceof Buffer) ? value : Put().word16be(value).buffer(),
                 pdu     = Put().word8be(6).word16be(address).put(payload).buffer();
 

--- a/src/handler/server/ReadCoils.js
+++ b/src/handler/server/ReadCoils.js
@@ -1,6 +1,4 @@
-var stampit     = require('stampit'),
-    Put         = require('put');
-
+var stampit     = require('stampit')
 
 module.exports = stampit()
     .init(function () {
@@ -26,9 +24,12 @@ module.exports = stampit()
 
                 if (pdu.length !== 5) {
                 
-                    cb(Put().word8(0x81).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x81, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return
                 }
 
                 var fc          = pdu.readUInt8(0),
@@ -41,14 +42,21 @@ module.exports = stampit()
 
                 if (start > mem.length * 8 || start + quantity > mem.length * 8) {
                 
-                    cb(Put().word8(0x81).word8(0x02).buffer());
-                    return;
-
+                  var buf = Buffer.allocUnsafe(2)
+                  buf.writeUInt8(0x81, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return
                 }
 
                 var val = 0, 
                     thisByteBitCount = 0,
-                    response = Put().word8(0x01).word8(Math.floor(quantity / 8) + (quantity % 8 === 0 ? 0 : 1));
+                    byteIdx = 2,
+                    byteCount = Math.ceil(quantity / 8),
+                    response = Buffer.allocUnsafe(2 + byteCount)
+
+                response.writeUInt8(0x01, 0)
+                response.writeUInt8(byteCount, 1);
 
                 for (var totalBitCount = start; totalBitCount < start + quantity; totalBitCount += 1) {
      
@@ -63,12 +71,12 @@ module.exports = stampit()
 
                     if (thisByteBitCount % 8 === 0 || totalBitCount === (start + quantity) - 1) {
                    
-                        response.word8(val);
-                        val = 0;
+                        response.writeUInt8(val, byteIdx)
+                        val = 0; byteIdx = byteIdx + 1
                     }
                 }
 
-                cb(response.buffer());
+                cb(response);
 
             }.bind(this), this.responseDelay);
             

--- a/src/handler/server/ReadDiscreteInputs.js
+++ b/src/handler/server/ReadDiscreteInputs.js
@@ -1,5 +1,4 @@
-var stampit     = require('stampit'),
-    Put         = require('put');
+var stampit     = require('stampit')
 
 var handler = stampit()
     .init(function () {
@@ -26,9 +25,15 @@ var handler = stampit()
 
                 if (pdu.length !== 5) {
                 
-                    cb(Put().word8(0x82).word8(0x02).buffer());
-                    return;
+                  this.log.debug('wrong pdu length.');
 
+                  var buf = Buffer.allocUnsafe(2)
+
+                  buf.writeUInt8(0x82, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+
+                  return;
                 }
 
                 var fc          = pdu.readUInt8(0),
@@ -41,14 +46,25 @@ var handler = stampit()
 
                 if (start > mem.length * 8 || start + quantity > mem.length * 8) {
                 
-                    cb(Put().word8(0x82).word8(0x02).buffer());
-                    return;
+                  this.log.debug('wrong pdu length.');
 
+                  var buf = Buffer.allocUnsafe(2)
+
+                  buf.writeUInt8(0x82, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+
+                  return
                 }
 
                 var val = 0, 
                     thisByteBitCount = 0,
-                    response = Put().word8(0x02).word8(Math.floor(quantity / 8) + (quantity % 8 === 0 ? 0 : 1));
+                    byteIdx = 2,
+                    byteCount = Math.ceil(quantity / 8),
+                    response = Buffer.allocUnsafe(2 + byteCount)
+
+                response.writeUInt8(0x02, 0)
+                response.writeUInt8(byteCount, 1);
 
                 for (var totalBitCount = start; totalBitCount < start + quantity; totalBitCount += 1) {
      
@@ -63,12 +79,12 @@ var handler = stampit()
 
                     if (thisByteBitCount % 8 === 0 || totalBitCount === (start + quantity) - 1) {
                    
-                        response.word8(val);
-                        val = 0;
+                        response.writeUInt8(val, byteIdx)
+                        val = 0; byteIdx = byteIdx + 1
                     }
                 }
 
-                cb(response.buffer());
+                cb(response);
 
             }.bind(this), this.responseDelay);
             

--- a/src/handler/server/ReadHoldingRegisters.js
+++ b/src/handler/server/ReadHoldingRegisters.js
@@ -1,6 +1,4 @@
-var stampit     = require('stampit'),
-    Put         = require('put');
-
+var stampit     = require('stampit')
 
 module.exports = stampit()
     .init(function () {
@@ -25,11 +23,15 @@ module.exports = stampit()
 
                 if (pdu.length !== 5) {
 
-                    this.log.debug('wrong pdu length.');
+                  this.log.debug('wrong pdu length.');
 
-                    cb(Put().word8(0x83).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x83, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+
+                  return;
                 }
 
                 var fc          = pdu.readUInt8(0),
@@ -43,23 +45,25 @@ module.exports = stampit()
 
                 if (byteStart > mem.length || byteStart + (quantity * 2) > mem.length) {
 
-                    this.log.debug('request outside register boundaries.');                
-                    cb(Put().word8(0x83).word8(0x02).buffer());
-                    return;
+                  this.log.debug('request outside register boundaries.');                
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x83, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return;
                 }
 
-                var response = Put().word8(0x03).word8(quantity * 2);
+                var head = Buffer.allocUnsafe(2)
+                 
+                head.writeUInt8(0x03, 0)
+                head.writeUInt8(quantity * 2, 1)
 
-                for (var i = byteStart; i < byteStart + (quantity * 2); i += 2) {
-         
-                    response.word16be(mem.readUInt16BE(i));
-
-                }
+                var response = Buffer.concat([head, mem.slice(byteStart * 2, byteStart * 2 + quantity * 2)])  
 
                 this.log.debug('finished read holding register request.');
 
-                cb(response.buffer());
+                cb(response);
 
             }.bind(this), this.responseDelay);
         

--- a/src/handler/server/ReadInputRegisters.js
+++ b/src/handler/server/ReadInputRegisters.js
@@ -1,6 +1,4 @@
-var stampit     = require('stampit'),
-    Put         = require('put');
-
+var stampit     = require('stampit')
 
 module.exports = stampit()
     .init(function () {
@@ -25,9 +23,12 @@ module.exports = stampit()
 
                 if (pdu.length !== 5) {
                 
-                    cb(Put().word8(0x84).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x84, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return;
                 }
 
                 var fc          = pdu.readUInt8(0),
@@ -41,20 +42,23 @@ module.exports = stampit()
 
                 if (byteStart > mem.length || byteStart + (quantity * 2) > mem.length) {
                 
-                    cb(Put().word8(0x84).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x84, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return;
                 }
 
-                var response = Put().word8(0x04).word8(quantity * 2);
+                var head = Buffer.allocUnsafe(2)
+                 
+                head.writeUInt8(0x04, 0)
+                head.writeUInt8(quantity * 2, 1)
 
-                for (var i = byteStart; i < byteStart + (quantity * 2); i += 2) {
-         
-                    response.word16be(mem.readUInt16BE(i));
+                var response = Buffer.concat([head, mem.slice(byteStart * 2, byteStart * 2 + quantity * 2)])  
 
-                }
 
-                cb(response.buffer());
+                cb(response);
 
             }.bind(this), this.responseDelay);
         

--- a/src/handler/server/WriteMultipleCoils.js
+++ b/src/handler/server/WriteMultipleCoils.js
@@ -1,6 +1,4 @@
-var stampit     = require('stampit'),
-    Put         = require('put');
-
+var stampit     = require('stampit')
 
 module.exports = stampit()
     .init(function () {
@@ -25,9 +23,12 @@ module.exports = stampit()
 
                 if (pdu.length < 3) {
                 
-                    cb(Put().word8(0x8F).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x8F, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return
                 }
 
                 var fc          = pdu.readUInt8(0),
@@ -42,13 +43,21 @@ module.exports = stampit()
                 // error response
                 if (start > mem.length * 8 || start + quantity > mem.length * 8) {
                 
-                    cb(Put().word8(0x8F).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x8F, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return
                 }
 
-                var response = Put().word8(0x0F).word16be(start).word16be(quantity).buffer(),
-                    oldValue, newValue, current = pdu.readUInt8(6 + 0), j = 0;
+                var response = Buffer.allocUnsafe(5)
+
+                response.writeUInt8(0x0F, 0)
+                response.writeUInt16BE(start, 1)
+                response.writeUInt16BE(quantity, 3)
+
+                var oldValue, newValue, current = pdu.readUInt8(6 + 0), j = 0;
 
                 for (var i = start; i < start + quantity; i += 1 ) {
 
@@ -72,9 +81,7 @@ module.exports = stampit()
                     if (j % 8 === 0 && j < quantity) {
 
                         current = pdu.readUInt8(6 +  Math.floor(j / 8));
-                    
                     }
-
                 }
 
                 this.emit('postWriteMultipleCoilsRequest', start, quantity, byteCount);

--- a/src/handler/server/WriteMultipleRegisters.js
+++ b/src/handler/server/WriteMultipleRegisters.js
@@ -1,6 +1,4 @@
-var stampit     = require('stampit'),
-    Put         = require('put');
-
+var stampit     = require('stampit')
 
 module.exports = stampit()
     .init(function () {
@@ -25,9 +23,12 @@ module.exports = stampit()
 
                 if (pdu.length < 3) {
                 
-                    cb(Put().word8(0x90).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x90, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return
                 }
 
                 var fc          = pdu.readUInt8(0),
@@ -38,9 +39,12 @@ module.exports = stampit()
 
                 if (quantity > 0x007b) {
                 
-                    cb(Put().word8(0x90).word8(0x03).buffer());
-                    return;
-                
+                  var buf = Buffer.allocUnsafe(2)
+
+                  buf.writeUInt8(0x90, 0)
+                  buf.writeUInt8(0x03, 1)
+                  cb(buf)
+                  return
                 }
 
                 this.emit('preWriteMultipleRegistersRequest', byteStart, quantity, byteCount);
@@ -49,21 +53,20 @@ module.exports = stampit()
 
                 if (byteStart > mem.length || byteStart + (quantity * 2) > mem.length) {
                 
-                    cb(Put().word8(0x90).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x90, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return
                 }
 
-                var response = Put().word8(0x10).word16be(start).word16be(quantity).buffer(),
-                    j = 0, currentByte;
+                var response = Buffer.allocUnsafe(5)
+                response.writeUInt8(0x10, 0)
+                response.writeUInt16BE(start, 1)
+                response.writeUInt16BE(quantity, 3)
 
-                for (var i = byteStart; i < byteStart + byteCount; i += 1) {
-                
-                    mem.writeUInt8(pdu.readUInt8(6 + j + 0), i);
-
-                    j += 1;   
-                
-                }
+                pdu.copy(mem, byteStart, 6, 6 + byteCount)
 
                 this.emit('postWriteMultipleRegistersRequest', byteStart, quantity, byteCount);
 

--- a/src/handler/server/WriteSingleCoil.js
+++ b/src/handler/server/WriteSingleCoil.js
@@ -1,6 +1,4 @@
-var stampit     = require('stampit'),
-    Put         = require('put');
-
+var stampit     = require('stampit')
 
 module.exports = stampit()
     .init(function () {
@@ -25,9 +23,12 @@ module.exports = stampit()
 
                 if (pdu.length !== 5) {
                 
-                    cb(Put().word8(0x85).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x85, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return
                 }
 
                 var fc          = pdu.readUInt8(0),
@@ -36,9 +37,12 @@ module.exports = stampit()
 
                 if (pdu.readUInt16BE(3) !== 0x0000 && pdu.readUInt16BE(3) !== 0xFF00) {
                 
-                    cb(Put().word8(0x85).word8(0x03).buffer());
-                    return; 
-                 
+                  var buf = Buffer.allocUnsafe(2)
+
+                  buf.writeUInt8(0x85, 0)
+                  buf.writeUInt8(0x03, 1)
+                  cb(buf)
+                  return
                 }
 
                 this.emit('preWriteSingleCoilRequest', address, value);
@@ -47,13 +51,21 @@ module.exports = stampit()
 
                 if (address > mem.length * 8) {
                 
-                    cb(Put().word8(0x85).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x85, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return
                 }
 
-                var response = Put().word8(0x05).word16be(address).word16be(value?0xFF00:0x0000),
-                    oldValue = mem.readUInt8(Math.floor(address / 8)),
+                var response = Buffer.allocUnsafe(5)
+
+                response.writeUInt8(5, 0)
+                response.writeUInt16BE(address, 1)
+                response.writeUInt16BE(value?0xFF00:0x0000, 3)
+
+                var oldValue = mem.readUInt8(Math.floor(address / 8)),
                     newValue;
                   
                 if (value) {
@@ -66,7 +78,7 @@ module.exports = stampit()
 
                 this.emit('postWriteSingleCoilRequest', address, value);
 
-                cb(response.buffer());
+                cb(response);
 
             }.bind(this), this.responseDelay);
         

--- a/src/handler/server/WriteSingleRegister.js
+++ b/src/handler/server/WriteSingleRegister.js
@@ -1,6 +1,4 @@
-var stampit     = require('stampit'),
-    Put         = require('put');
-
+var stampit     = require('stampit')
 
 module.exports = stampit()
     .init(function () {
@@ -25,9 +23,12 @@ module.exports = stampit()
 
                 if (pdu.length !== 5) {
                 
-                    cb(Put().word8(0x86).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x86, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return
                 }
 
                 var fc          = pdu.readUInt8(0),
@@ -41,12 +42,19 @@ module.exports = stampit()
 
                 if (byteAddress > mem.length) {
                 
-                    cb(Put().word8(0x86).word8(0x02).buffer());
-                    return;
+                  var buf = Buffer.allocUnsafe(2)
 
+                  buf.writeUInt8(0x86, 0)
+                  buf.writeUInt8(0x02, 1)
+                  cb(buf)
+                  return
                 }
 
-                var response = Put().word8(0x06).word16be(address).word16be(value).buffer();
+                var response = Buffer.allocUnsafe(5)
+
+                response.writeUInt8(0x06)
+                response.writeUInt16BE(address, 1)
+                response.writeUInt16BE(value, 3)
 
                 mem.writeUInt16BE(value, byteAddress); 
 

--- a/src/modbus-client-core.js
+++ b/src/modbus-client-core.js
@@ -1,4 +1,3 @@
-
 var Util            = require('util'),
     stampit         = require('stampit'),
     Log             = require('stampit-log'),

--- a/src/modbus-client-core.js
+++ b/src/modbus-client-core.js
@@ -1,6 +1,5 @@
 
 var Util            = require('util'),
-    Put             = require('put'),
     stampit         = require('stampit'),
     Log             = require('stampit-log'),
     StateMachine    = require('stampit-state-machine');

--- a/src/modbus-server-core.js
+++ b/src/modbus-server-core.js
@@ -1,5 +1,4 @@
 var stampit         = require('stampit'),
-    Put             = require('put'),
     EventBus        = require('stampit-event-bus'),
     Log             = require('stampit-log');
 
@@ -48,7 +47,11 @@ var stampit         = require('stampit'),
           
                 this.log.debug('no handler for fc', fc);
 
-                callback(Put().word8(fc + 0x80).word8(0x01).buffer());
+                var buf = Buffer.alloc(2)
+                buf.writeUInt8(fc + 0x80, 0)
+                buf.writeUInt8(0x01, 1)
+
+                callback(buf)
 
                 return;
             

--- a/src/modbus-tcp-client.js
+++ b/src/modbus-tcp-client.js
@@ -1,5 +1,4 @@
 var stampit         = require('stampit'),
-    Put             = require('put'),
     Net             = require('net'),
     ModbusCore      = require('./modbus-client-core.js');
 
@@ -147,13 +146,14 @@ module.exports = stampit()
 
             reqId += 1;
 
-            var pkt = Put()
-                .word16be(reqId)                 // transaction id
-                .word16be(this.protocolVersion) // protocol version
-                .word16be(pdu.length + 1)        // pdu length
-                .word8(this.unitId)	             // unit id
-                .put(pdu)                        // the actual pdu
-                .buffer();
+            var head = Buffer.allocUnsafe(7)
+
+            head.writeUInt16BE(reqId, 0)
+            head.writeUInt16BE(this.protocolVersion, 2)
+            head.writeUInt16BE(pdu.length + 1, 4)
+            head.writeUInt8(this.unitId, 6)
+
+            var pkt = Buffer.concat([head, pdu])
 
             currentRequestId = reqId;
 

--- a/src/modbus-tcp-server.js
+++ b/src/modbus-tcp-server.js
@@ -1,7 +1,6 @@
 var stampit             = require('stampit'),
     ModbusServerCore    = require('./modbus-server-core.js'),
     StateMachine        = require('stampit-state-machine'),
-    Put                 = require('put'),
     net                 = require('net');
 
 module.exports = stampit()
@@ -112,13 +111,14 @@ module.exports = stampit()
  
                 this.log.debug('sending tcp data');
 
-                 var pkt = Put()
-                    .word16be(current.request.trans_id)         // transaction id
-                    .word16be(current.request.protocol_ver)     // protocol version
-                    .word16be(response.length + 1)      // pdu length
-                    .word8(current.request.unit_id)             // unit id
-                    .put(response)                      // the actual pdu
-                    .buffer();
+                var head = Buffer.allocUnsafe(7)
+
+                head.writeUInt16BE(current.request.trans_id, 0)
+                head.writeUInt16BE(current.request.protocol_ver, 2)
+                head.writeUInt16BE(response.length + 1, 4)
+                head.writeUInt8(current.request.unit_id, 6)
+
+                var pkt = Buffer.concat([head, response])
 
                 current.socket.write(pkt); 
            

--- a/test/modbus-client-core.test.js
+++ b/test/modbus-client-core.test.js
@@ -1,8 +1,5 @@
-
-
 var stampit         = require('stampit'),
-    assert          = require("assert"),
-    Put             = require('put'),
+    assert          = require('assert'),
     sinon           = require('sinon'),
     util            = require('util'),
     eventEmitter    = require('events').EventEmitter;
@@ -27,7 +24,7 @@ describe("Modbus Serial Client", function () {
                 assert.equal(resp.fc, 1);
                 assert.equal(resp.byteCount, 2);
                 assert.equal(resp.coils.length, 16);
-                assert.deepEqual(resp.payload, new Buffer([85, 1]))
+                assert.deepEqual(resp.payload, Buffer.from([85, 1]))
                 assert.deepEqual(resp.coils, [true, false, true, false, true, false, true, false, true, false, false, false, false, false, false, false]);
             
                 done();
@@ -35,9 +32,7 @@ describe("Modbus Serial Client", function () {
             }).done();
 
             client.setState('ready');
-            client.emit('data', Put().word8(1).word8be(2).word8be(85).word8be(1).buffer() );
-
-
+            client.emit('data', Buffer.from([1,2,85,1]));
         });
 
         it("Should fail reading coils.", function (done) {
@@ -51,7 +46,7 @@ describe("Modbus Serial Client", function () {
             }).done();
 
             client.setState('ready');
-            client.emit('data', Put().word8be(0x81).word8be(1).buffer());
+            client.emit('data', Buffer.from([0x81, 0x01]))
         
         });
 
@@ -71,7 +66,7 @@ describe("Modbus Serial Client", function () {
                 assert.equal(resp.fc, 2);
                 assert.equal(resp.byteCount, 1);
                 assert.equal(resp.coils.length, 8);
-                assert.deepEqual(resp.payload, new Buffer([15]));
+                assert.deepEqual(resp.payload, Buffer.from([15]));
                 assert.deepEqual(resp.coils, [true, true, true, true, false, false, false, false]);
 
                 done();
@@ -79,7 +74,7 @@ describe("Modbus Serial Client", function () {
             }).done();
 
             client.setState('ready');
-            client.emit('data', Put().word8be(2).word8be(1).word8be(15).buffer());
+            client.emit('data', Buffer.from([0x02, 0x01, 0x0F]))
         
         });
 
@@ -98,7 +93,7 @@ describe("Modbus Serial Client", function () {
             }).done();
 
             client.setState('ready');
-            client.emit('data', Put().word8be(0x82).word8be(0x02).buffer()); 
+            client.emit('data', Buffer.from([0x82, 0x02]))
         
         });
     
@@ -118,7 +113,7 @@ describe("Modbus Serial Client", function () {
            
                 assert.equal(resp.fc, 3);
                 assert.equal(resp.byteCount, 10);
-                assert.deepEqual(resp.payload, new Buffer([0,1,0,2,0,3,0,4,0,5]));
+                assert.deepEqual(resp.payload, Buffer.from([0,1,0,2,0,3,0,4,0,5]));
                 assert.deepEqual(resp.register, [1, 2, 3, 4, 5]);
 
                 done();
@@ -128,15 +123,7 @@ describe("Modbus Serial Client", function () {
             client.setState('ready');
             client.emit(
                 'data', 
-                Put()
-                    .word8be(3)
-                    .word8be(10)
-                    .word16be(1)
-                    .word16be(2)
-                    .word16be(3)
-                    .word16be(4)
-                    .word16be(5)
-                    .buffer()
+                Buffer.from([0x03,0x0A,0x00,0x01,0x00,0x02,0x00,0x03,0x00,0x04,0x00,0x05])
             );
         
         });
@@ -156,7 +143,7 @@ describe("Modbus Serial Client", function () {
             }).done();
 
             client.setState('ready');
-            client.emit('data', Put().word8be(0x83).word8be(0x03).buffer()); 
+            client.emit('data', Buffer.from([0x83,0x03]))
         
         });
     
@@ -176,7 +163,7 @@ describe("Modbus Serial Client", function () {
          
                 assert.equal(resp.fc, 4);
                 assert.equal(resp.byteCount, 10);
-                assert.deepEqual(resp.payload, new Buffer([0,5,0,4,0,3,0,2,0,1]))
+                assert.deepEqual(resp.payload, Buffer.from([0,5,0,4,0,3,0,2,0,1]))
                 assert.deepEqual(resp.register, [5, 4, 3, 2, 1]);
 
                 done();
@@ -186,15 +173,7 @@ describe("Modbus Serial Client", function () {
             client.setState('ready');
             client.emit(
                 'data', 
-                Put()
-                    .word8be(4)
-                    .word8be(10)
-                    .word16be(5)
-                    .word16be(4)
-                    .word16be(3)
-                    .word16be(2)
-                    .word16be(1)
-                    .buffer()
+                Buffer.from([0x04,0x0A,0x00,0x05,0x00,0x04,0x00,0x03,0x00,0x02,0x00,0x01])
             );
         
         });
@@ -214,7 +193,7 @@ describe("Modbus Serial Client", function () {
             }).done();
 
             client.setState('ready');
-            client.emit('data', Put().word8be(0x84).word8be(0x03).buffer()); 
+            client.emit('data', Buffer.from([0x84,0x03]))
         
         });
     
@@ -249,11 +228,7 @@ describe("Modbus Serial Client", function () {
             client.setState('ready');
             client.emit(
                 'data', 
-                Put()
-                    .word8be(5)
-                    .word16be(3)
-                    .word16be(0xFF00)
-                    .buffer()
+                Buffer.from([0x05,0x00,0x03,0xFF,0x00])
             );
         });
 
@@ -261,7 +236,7 @@ describe("Modbus Serial Client", function () {
         
             var client = ModbusClient(true);
 
-            client.writeSingleCoil(3, new Buffer([1])).then(function (resp) {
+            client.writeSingleCoil(3, Buffer.from([1])).then(function (resp) {
            
                 assert.equal(resp.fc, 5);
                 assert.equal(resp.outputAddress, 3);
@@ -280,11 +255,7 @@ describe("Modbus Serial Client", function () {
             client.setState('ready');
             client.emit(
                 'data', 
-                Put()
-                    .word8be(5)
-                    .word16be(3)
-                    .word16be(0xFF00)
-                    .buffer()
+                Buffer.from([0x05,0x00,0x03,0xFF,0x00])
             );
         });
 
@@ -292,7 +263,7 @@ describe("Modbus Serial Client", function () {
         
             var client = ModbusClient(true);
 
-            client.writeSingleCoil(3, new Buffer([0])).then(function (resp) {
+            client.writeSingleCoil(3, Buffer.from([0])).then(function (resp) {
            
                 assert.equal(resp.fc, 5);
                 assert.equal(resp.outputAddress, 3);
@@ -311,11 +282,7 @@ describe("Modbus Serial Client", function () {
             client.setState('ready');
             client.emit(
                 'data', 
-                Put()
-                    .word8be(5)
-                    .word16be(3)
-                    .word16be(0x0000)
-                    .buffer()
+                Buffer.from([0x05,0x00,0x03,0x00,0x00])
             );
         });
 
@@ -334,8 +301,7 @@ describe("Modbus Serial Client", function () {
             }).done();
 
             client.setState('ready');
-            client.emit('data', Put().word8be(0x85).word8be(0x04).buffer()); 
-        
+            client.emit('data', Buffer.from([0x85,0x04]))
         });
     
     
@@ -369,11 +335,7 @@ describe("Modbus Serial Client", function () {
             client.setState('ready');
             client.emit(
                 'data', 
-                Put()
-                    .word8be(6)
-                    .word16be(3)
-                    .word16be(123)
-                    .buffer()
+                Buffer.from([0x06,0x00,0x03,0x00,0x7B])
             );
         
         });
@@ -382,7 +344,7 @@ describe("Modbus Serial Client", function () {
         
             var client = ModbusClient(true);
 
-            client.writeSingleRegister(3, new Buffer([0x00, 0x7b])).then(function (resp) {
+            client.writeSingleRegister(3, Buffer.from([0x00, 0x7b])).then(function (resp) {
            
                 assert.equal(resp.fc, 6);
                 assert.equal(resp.registerAddress, 3);
@@ -401,11 +363,7 @@ describe("Modbus Serial Client", function () {
             client.setState('ready');
             client.emit(
                 'data', 
-                Put()
-                    .word8be(6)
-                    .word16be(3)
-                    .word16be(123)
-                    .buffer()
+                Buffer.from([0x06,0x00,0x03,0x00,0x7B])
             );
         });
 
@@ -424,7 +382,7 @@ describe("Modbus Serial Client", function () {
             }).done();
 
             client.setState('ready');
-            client.emit('data', Put().word8be(0x86).word8be(0x01).buffer()); 
+            client.emit('data', Buffer.from([0x86,0x01]))
         
         });
     
@@ -464,14 +422,7 @@ describe("Modbus Serial Client", function () {
             client.setState('ready');
             client.emit(
                 'data', 
-                Put()
-                    .word8be(15)
-                    .word16be(20)
-                    .word16be(10)
-                    .word8be(2)
-                    .word8be(0xCD)
-                    .word8be(0x01)
-                    .buffer()
+                Buffer.from([0x0F,0x00,0x14,0x00,0x0A,0x02,0xCD,0x01])
             );
         });
 
@@ -479,7 +430,7 @@ describe("Modbus Serial Client", function () {
         
             var client = ModbusClient(true);
 
-            client.writeMultipleCoils(20, new Buffer([0xCD, 0x01]), 10)
+            client.writeMultipleCoils(20, Buffer.from([0xCD, 0x01]), 10)
             .then(function (resp) {
            
                 assert.equal(resp.fc, 15);
@@ -503,14 +454,7 @@ describe("Modbus Serial Client", function () {
             client.setState('ready');
             client.emit(
                 'data', 
-                Put()
-                    .word8be(15)
-                    .word16be(20)
-                    .word16be(10)
-                    .word8be(2)
-                    .word8be(0xCD)
-                    .word8be(0x01)
-                    .buffer()
+                Buffer.from([0x0F,0x00,0x14,0x00,0x0A,0x02,0xCD,0x01])
             );
         
         });
@@ -530,7 +474,7 @@ describe("Modbus Serial Client", function () {
             }).done();
 
             client.setState('ready');
-            client.emit('data', Put().word8be(0x8F).word8be(0x02).buffer()); 
+            client.emit('data', Buffer.from([0x8F, 0x02]))
         
         });
     
@@ -569,14 +513,7 @@ describe("Modbus Serial Client", function () {
             client.setState('ready');
             client.emit(
               'data', 
-              Put()
-                .word8be(16)
-                .word16be(3)
-                .word16be(3)
-                .word16be(1)
-                .word16be(2)
-                .word16be(350)
-                .buffer()
+              Buffer.from([0x10,0x00,0x03,0x00,0x03,0x00,0x01,0x00,0x02,0x01,0x6F])
             );
         });
 
@@ -584,7 +521,7 @@ describe("Modbus Serial Client", function () {
         
           var client = ModbusClient(true);
 
-          client.writeMultipleRegisters(3, new Buffer([0x00, 0xc4]))
+          client.writeMultipleRegisters(3, Buffer.from([0x00, 0xc4]))
           
           var pdu = client.queueSpy().pdu
 
@@ -611,7 +548,7 @@ describe("Modbus Serial Client", function () {
             }).done();
 
             client.setState('ready');
-            client.emit('data', Put().word8be(0x90).word8be(0x02).buffer()); 
+            client.emit('data', Buffer.from([0x90, 0x02]))
         
         });
     
@@ -659,15 +596,7 @@ describe("Modbus Serial Client", function () {
  
                 client.emit(
                     'data', 
-                    Put()
-                        .word8be(3)
-                        .word8be(10)
-                        .word16be(1)
-                        .word16be(2)
-                        .word16be(3)
-                        .word16be(4)
-                        .word16be(5)
-                        .buffer()
+                    Buffer.from([0x03,0x0A,0x00,0x01,0x00,0x02,0x00,0x03,0x00,0x04,0x00,0x05])
                     );
             
                 done();

--- a/test/modbus-client-core.test.js
+++ b/test/modbus-client-core.test.js
@@ -44,7 +44,7 @@ describe("Modbus Serial Client", function () {
         
             var client = ModbusClient();
 
-            client.readCoils(0, 10).fail(function (resp) {
+            client.readCoils(0, 10).catch(function (resp) {
             
                 done();
 
@@ -91,7 +91,7 @@ describe("Modbus Serial Client", function () {
             
                 assert.ok(false);
             
-            }).fail(function (err) {
+            }).catch(function (err) {
             
                 done();
             
@@ -149,7 +149,7 @@ describe("Modbus Serial Client", function () {
             
                 assert.ok(false);
             
-            }).fail(function (err) {
+            }).catch(function (err) {
             
                 done();
             
@@ -207,7 +207,7 @@ describe("Modbus Serial Client", function () {
             
                 assert.ok(false);
             
-            }).fail(function (err) {
+            }).catch(function (err) {
             
                 done();
             
@@ -327,7 +327,7 @@ describe("Modbus Serial Client", function () {
             
                 done(true);
 
-            }).fail(function (err) {
+            }).catch(function (err) {
             
                 done();
             
@@ -417,7 +417,7 @@ describe("Modbus Serial Client", function () {
             
                 done(true);
 
-            }).fail(function (err) {
+            }).catch(function (err) {
             
                 done();
             
@@ -523,7 +523,7 @@ describe("Modbus Serial Client", function () {
             
                 done(true);
 
-            }).fail(function (err) {
+            }).catch(function (err) {
             
                 done();
             
@@ -604,7 +604,7 @@ describe("Modbus Serial Client", function () {
             
                 done(true);
 
-            }).fail(function (err) {
+            }).catch(function (err) {
             
                 done();
             
@@ -628,14 +628,12 @@ describe("Modbus Serial Client", function () {
             var client = ModbusClient({ 'timeout' : 200 });
 
             client.readHoldingRegisters(3, 10).then(function (resp) {
-           
-                done(true);
             
-            }).fail(function (err) {
+            }).catch(function (err) {
             
-                done(err.err !== 'timeout');
-
-            }).done();
+                assert.equal(err.err, 'timeout');
+                done()
+            });
 
             client.setState('ready');
        
@@ -649,7 +647,7 @@ describe("Modbus Serial Client", function () {
            
                 done(true);
             
-            }).fail(function (err) {
+            }).catch(function (err) {
             
                 assert.equal(err.err, 'timeout');
 

--- a/test/modbus-server-core.test.js
+++ b/test/modbus-server-core.test.js
@@ -1,6 +1,5 @@
 var stampit         = require('stampit'),
-    assert          = require("assert"),
-    Put             = require('put'),
+    assert          = require('assert'),
     sinon           = require('sinon'),
     util            = require('util'),
     eventEmitter    = require('events').EventEmitter;
@@ -14,15 +13,13 @@ describe("Modbus Server Core Tests.", function () {
         it('should answer with 0x8x status code due to missing handler.', function (done) {
         
             var core        = ModbusCore(),
-                request     = Put().word8(1).word16be(0).word16be(10).buffer(),
-                exResponse  = Put().word8(0x81).word8(0x01).buffer();
+                request     = Buffer.from([0x01,0x00,0x00,0x00,0x0A]),
+                exResponse  = Buffer.from([0x81,0x01])
 
             var resp = function (response) {
            
                 assert.equal(response.compare(exResponse), 0);
-
                 done();
-            
             };
 
             core.onData(request, resp); 
@@ -39,8 +36,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read coils request just fine.', function (done) {
 
             var core        = Core(),
-                request     = Put().word8(0x01).word16be(0).word16be(5).buffer(),
-                exResponse  = Put().word8(0x01).word8(1).word8(0x15).buffer();         
+                request     = Buffer.from([0x01,0x00,0x00,0x00,0x05]),
+                exResponse  = Buffer.from([0x01,0x01,0x15]);
 
             core.getCoils().writeUInt8(0x15, 0); 
 
@@ -59,8 +56,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read coils request with odd start address just fine.', function (done) {
 
             var core        = Core(),
-                request     = Put().word8(0x01).word16be(2).word16be(5).buffer(),
-                exResponse  = Put().word8(0x01).word8(1).word8(0x05).buffer();         
+                request     = Buffer.from([0x01,0x00,0x02,0x00,0x05]),
+                exResponse  = Buffer.from([0x01,0x01,0x05]);         
 
             core.getCoils().writeUInt8(0x15, 0); 
 
@@ -79,8 +76,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read coils request with a start address outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x01).word16be(1024 * 8 + 1).word16be(10).buffer(),
-                exResponse  = Put().word8(0x81).word8be(0x02).buffer();
+                request     = Buffer.from([0x01,0x20,0x01,0x00,10]),
+                exResponse  = Buffer.from([0x81,0x02]);
 
             var resp = function (response) {
             
@@ -97,8 +94,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read coils request with a quantity value outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x01).word16be(1023 * 8).word16be(9).buffer(),
-                exResponse  = Put().word8(0x81).word8be(0x02).buffer();
+                request     = Buffer.from([0x01,0x1f,0xf8,0x00,9]),
+                exResponse  = Buffer.from([0x81,0x02]);
 
             var resp = function (response) {
             
@@ -122,8 +119,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read discrete inputs request just fine.', function (done) {
 
             var core        = Core(),
-                request     = Put().word8(0x02).word16be(0).word16be(5).buffer(),
-                exResponse  = Put().word8(0x02).word8(1).word8(0x15).buffer();         
+                request     = Buffer.from([0x02,0x00,0,0x00,5]),
+                exResponse  = Buffer.from([0x02,1,0x15]);         
      
             core.getInput().writeUInt8(0x15, 0); 
 
@@ -142,8 +139,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read discrete inputs request with odd start address just fine.', function (done) {
 
             var core        = Core(),
-                request     = Put().word8(0x02).word16be(2).word16be(5).buffer(),
-                exResponse  = Put().word8(0x02).word8(1).word8(0x05).buffer();         
+                request     = Buffer.from([0x02,0x00,2,0x00,5]),
+                exResponse  = Buffer.from([0x02,1,0x05]);         
      
             core.getInput().writeUInt8(0x15, 0); 
 
@@ -162,8 +159,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read discrete inputs request with a start address outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x02).word16be(1024 * 8 + 1).word16be(10).buffer(),
-                exResponse  = Put().word8(0x82).word8be(0x02).buffer();
+                request     = Buffer.from([0x02,0x20,0x01,0x00,10]),
+                exResponse  = Buffer.from([0x82,0x02]);
 
             var resp = function (response) {
             
@@ -180,8 +177,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read discrete inputs request with a quantity value outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x02).word16be(1023 * 8).word16be(9).buffer(),
-                exResponse  = Put().word8(0x82).word8be(0x02).buffer();
+                request     = Buffer.from([0x02,0x1F,0xF8,0x00,9]),
+                exResponse  = Buffer.from([0x82,0x02]);
 
             var resp = function (response) {
             
@@ -205,8 +202,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read holding registers request just fine.', function (done) {
 
             var core        = Core(),
-                request     = Put().word8(0x03).word16be(0).word16be(5).buffer(),
-                exResponse  = Put().word8(0x03).word8(10).word16be(1).word16be(2).word16be(3).word16be(4).word16be(5).buffer();          
+                request     = Buffer.from([0x03,0x00,0,0x00,5]),
+                exResponse  = Buffer.from([0x03,10,0x00,1,0x00,2,0x00,3,0x00,4,0x00,5]);          
             core.getHolding().writeUInt16BE(0x01, 0); 
             core.getHolding().writeUInt16BE(0x02, 2); 
             core.getHolding().writeUInt16BE(0x03, 4); 
@@ -228,8 +225,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read holding registers request with a start address outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x03).word16be(1024 + 1).word16be(10).buffer(),
-                exResponse  = Put().word8(0x83).word8be(0x02).buffer();
+                request     = Buffer.from([0x03,0x04,0x05,0x00,10]),
+                exResponse  = Buffer.from([0x83,0x02]);
 
             var resp = function (response) {
             
@@ -246,8 +243,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read holding registers request with a quantity value outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x03).word16be(1023).word16be(1).buffer(),
-                exResponse  = Put().word8(0x83).word8be(0x02).buffer();
+                request     = Buffer.from([0x03,0x04,0x03,0x00,1]),
+                exResponse  = Buffer.from([0x83,0x02]);
 
             var resp = function (response) {
             
@@ -272,8 +269,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read input registers request just fine.', function (done) {
 
             var core        = Core(),
-                request     = Put().word8(0x04).word16be(0).word16be(5).buffer(),
-                exResponse  = Put().word8(0x04).word8(10).word16be(5).word16be(4).word16be(3).word16be(2).word16be(1).buffer();          
+                request     = Buffer.from([0x04,0x00,0,0x00,5]),
+                exResponse  = Buffer.from([0x04,10,0x00,5,0x00,4,0x00,3,0x00,2,0x00,1]);          
             core.getInput().writeUInt16BE(0x05, 0); 
             core.getInput().writeUInt16BE(0x04, 2); 
             core.getInput().writeUInt16BE(0x03, 4); 
@@ -295,8 +292,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read input registers request with a start address outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x04).word16be(1024 +1).word16be(10).buffer(),
-                exResponse  = Put().word8(0x84).word8be(0x02).buffer();
+                request     = Buffer.from([0x04,0x04,0x05,0x00,10]),
+                exResponse  = Buffer.from([0x84,0x02]);
 
             var resp = function (response) {
             
@@ -313,8 +310,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read input registers request with a quantity value outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x04).word16be(1023).word16be(1).buffer(),
-                exResponse  = Put().word8(0x84).word8be(0x02).buffer();
+                request     = Buffer.from([0x04,0x04,0x03,0x00,1]),
+                exResponse  = Buffer.from([0x84,0x02]);
 
             var resp = function (response) {
             
@@ -337,8 +334,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write single coil request just fine.', function (done) {
 
             var core        = Core(),
-                request     = Put().word8(0x05).word16be(8).word16be(0xff00).buffer(),
-                exResponse  = Put().word8(0x05).word16be(8).word16be(0xff00).buffer();
+                request     = Buffer.from([0x05,0x00,8,0xff,0x00]),
+                exResponse  = Buffer.from([0x05,0x00,8,0xff,0x00]);
 
             core.getCoils().writeUInt8(0, 1);
 
@@ -358,8 +355,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write single coil request with a start address outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x05).word16be(1024 * 8 + 1).word16be(0xff00).buffer(),
-                exResponse  = Put().word8(0x85).word8be(0x02).buffer();
+                request     = Buffer.from([0x05,0x20,0x01,0x00,0xff00]),
+                exResponse  = Buffer.from([0x85,0x02]);
 
             var resp = function (response) {
             
@@ -376,8 +373,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write single coil request with a another value than 0x0000 (false) and 0xff00 (true).', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x05).word16be(8).word16be(0xf300).buffer(),
-                exResponse  = Put().word8(0x85).word8be(0x03).buffer();
+                request     = Buffer.from([0x05,0x00,8,0xf3,0x00]),
+                exResponse  = Buffer.from([0x85,0x03]);
 
             var resp = function (response) {
             
@@ -403,8 +400,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write single register request just fine.', function (done) {
 
             var core        = Core(),
-                request     = Put().word8(0x06).word16be(8).word16be(0x0123).buffer(),
-                exResponse  = Put().word8(0x06).word16be(8).word16be(0x0123).buffer();
+                request     = Buffer.from([0x06,0x00,8,0x01,0x23]),
+                exResponse  = Buffer.from([0x06,0x00,8,0x01,0x23]);
 
             core.getHolding().writeUInt16BE(0x0123, 8);
 
@@ -424,8 +421,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write single register request with a start address outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x06).word16be(1024 + 1).word16be(0x0123).buffer(),
-                exResponse  = Put().word8(0x86).word8be(0x02).buffer();
+                request     = Buffer.from([0x06,0x04,0x05,0x01,0x23]),
+                exResponse  = Buffer.from([0x86,0x02]);
 
             var resp = function (response) {
             
@@ -449,8 +446,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write multiple coils request just fine.', function (done) {
 
             var core        = Core(),
-                request     = Put().word8(0x0F).word16be(12).word16be(4).word8(1).word8(0x0F).buffer(),
-                exResponse  = Put().word8(0x0F).word16be(12).word16be(4).buffer();
+                request     = Buffer.from([0x0F,0x00,12,0x00,4,1,0x0F]),
+                exResponse  = Buffer.from([0x0F,0x00,12,0x00,4]);
 
             core.getCoils().writeUInt8(0x0F, 1);
 
@@ -470,8 +467,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write multiple coils request with a start address outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x0F).word16be(1024 * 8 + 1).word16be(4).word8(1).word8(0x0F).buffer(),
-                exResponse  = Put().word8(0x8F).word8be(0x02).buffer();
+                request     = Buffer.from([0x0F,0x20,0x01,0x00,0x04,0x01,0x0F]),
+                exResponse  = Buffer.from([0x8F,0x02]);
 
             var resp = function (response) {
             
@@ -488,8 +485,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write multiple coils request with a start and quantity outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x0F).word16be(1024 * 8 - 3).word16be(4).word8(1).word8(0x0F).buffer(),
-                exResponse  = Put().word8(0x8F).word8be(0x02).buffer();
+                request     = Buffer.from([0x0F,0x1F,0xFD,0x00,4,1,0x0F]),
+                exResponse  = Buffer.from([0x8F,0x02]);
 
             var resp = function (response) {
             
@@ -514,20 +511,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write multiple registers request just fine.', function (done) {
 
             var core        = Core(),
-                request     = Put()
-                    .word8(0x10)
-                    .word16be(5)
-                    .word16be(3)
-                    .word8(6)
-                    .word16be(0x0001)
-                    .word16be(0x0002)
-                    .word16be(0x0003)
-                    .buffer(),
-                exResponse  = Put()
-                    .word8(0x10)
-                    .word16be(5)
-                    .word16be(3)
-                    .buffer();
+                request     = Buffer.from([0x10,0x00,0x05,0x00,0x03,0x06,0x00,0x01,0x00,0x02,0x00,0x03]),
+                exResponse  = Buffer.from([0x10,0x00,0x05,0x00,0x03])
 
             core.getHolding().writeUInt16BE(0x0000, 10);
             core.getHolding().writeUInt16BE(0x0000, 12);
@@ -551,8 +536,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write multiple registers request with a start address outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x10).word16be(1025).word16be(2).word8(4).word16be(0x01).word16be(0x02).buffer(),
-                exResponse  = Put().word8(0x90).word8be(0x02).buffer();
+                request     = Buffer.from([0x10,0x04,0x05,0x00,0x02,0x04,0x00,0x01,0x00,0x02]),
+                exResponse  = Buffer.from([0x90,0x02]);
 
             var resp = function (response) {
             
@@ -569,8 +554,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write multiple registers request with a start and quantity outside the address space.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x10).word16be(1022).word16be(2).word8(4).word16be(0x01).word16be(0x02).buffer(),
-                exResponse  = Put().word8(0x90).word8be(0x02).buffer();
+                request     = Buffer.from([0x10,0x04,0x02,0x00,0x02,0x04,0x00,0x01,0x00,0x02]),
+                exResponse  = Buffer.from([0x90,0x02]);
 
             var resp = function (response) {
             
@@ -587,8 +572,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a write multiple registers request with a quantity greater 0x007b.', function (done) {
         
             var core        = Core(),
-                request     = Put().word8(0x10).word16be(0).word16be(0x007c).word8(0xf8).word16be(0x01).word16be(0x02).buffer(),
-                exResponse  = Put().word8(0x90).word8be(0x03).buffer();
+                request     = Buffer.from([0x10,0x00,0x00,0x00,0x7c,0xf8,0x00,0x01,0x00,0x02]),
+                exResponse  = Buffer.from([0x90,0x03]);
 
             var resp = function (response) {
             


### PR DESCRIPTION
While analyzing a memory leak (in our code) we learned that this lib had two major optimization potentials, especially regarding the `reqFifo`. This Pull Request solves both of these (details below) by replacing the Promise library `Q` with its more performant counterpart `bluebird` and completely removes the `Put` dependency (which hasn't been touched for the last 5 years anyway).

------

Details: 

we had a situation where requests where queueing in huge amounts leading to an out-of-memory error. While the fact that the requests where queuing is our fault, the memory usage was much higher than we thought it should be. We therefore created the following minimal test (against a locally running mock modbus server):

```
const modbus = require('jsmodbus')
const v8 = require('v8')

const client = modbus.client.tcp.complete({
        'host'              : 'localhost',
        'port'              : 8888,
})

client.connect()

client.on('connect', function () {
   for(let i=1; i < 1e5; i++)
     client.readCoils(0, 13)

   console.log('Heap:', Math.floor(v8.getHeapStatistics().used_heap_size / 1e6), 'MB')
})
```

the result:

```
# ORIGINAL MEMORY USAGE
$ node index.js 
Heap: 221 MB
```

after replacing `Q` with `bluebird` (only in `readCoils` for this test)

```
# MEMORY USAGE WITH BLUEBIRD INSTEAD OF Q
$ node index.js 
Heap: 109 MB
```

after getting rid of `Put` in favor of pure `Buffer` (also only in `readCoils` for this test)

```
# MEMORY USAGE WITH BLUEBIRD + Buffer INSTEAD OF Put
$ node index.js
Heap: 41 MB
```

after consequently updating the whole lib with these new findings (=> the current PR), it went even further down:

```
# MEMORY USAGE WITH COMPLETE REFACTORING (current PR)
$ node index.js
Heap: 35 MB
```