### PR TITLE
Fix typo and code style formatting

### DIFF
--- a/src/handler/client/ReadDiscreteInputs.js
+++ b/src/handler/client/ReadDiscreteInputs.js
@@ -12,7 +12,7 @@ module.exports = Stampit()
     
         var onResponse = function (pdu, request) {
  
-            this.log.debug("handeling read discrete inputs response.");
+            this.log.debug("handling read discrete inputs response.");
 
             var fc          = pdu.readUInt8(0),
                 byteCount   = pdu.readUInt8(1),
@@ -29,9 +29,9 @@ module.exports = Stampit()
                 return;
             }
 
-            for (var i = 0; i < byteCount; i+=1) {
+            for (var i = 0; i < byteCount; i += 1) {
                 var h = 1, cur = pdu.readUInt8(2 + i);
-                for (var j = 0; j < 8; j+=1) {
+                for (var j = 0; j < 8; j += 1) {
                     resp.coils[cntr] = (cur & h) > 0 ;
                     h = h << 1;
                     cntr += 1;
@@ -46,11 +46,11 @@ module.exports = Stampit()
  
             var fc      = 2,
                 defer   = Promise.defer(),
-                pdu     = Buffer.allocUnsafe(5)
+                pdu     = Buffer.allocUnsafe(5);
 
-            pdu.writeUInt8(fc)
-            pdu.writeUInt16BE(start,1)
-            pdu.writeUInt16BE(quantity,3)
+            pdu.writeUInt8(fc);
+            pdu.writeUInt16BE(start, 1);
+            pdu.writeUInt16BE(quantity, 3);
 
             if (quantity > 2000) {    
 


### PR DESCRIPTION
It is very strange. Some commands are with semicolon, some without. Some have spaces "i += 1;", some not "i+=1;"