### PR TITLE
Fix byte bugs

### DIFF
--- a/src/handler/client/WriteSingleRegister.js
+++ b/src/handler/client/WriteSingleRegister.js
@@ -22,8 +22,8 @@ module.exports = Stampit()
                 fc              : fc,
                 registerAddress : registerAddress,
                 registerValue   : registerValue,
-                registerAddressRaw: pdu.slice(1,2),
-                registerValueRaw: pdu.slice(3,2)
+                registerAddressRaw: pdu.slice(1,3),
+                registerValueRaw: pdu.slice(3,5)
             };
 
             if (fc !== 6) {

--- a/src/handler/server/ReadHoldingRegisters.js
+++ b/src/handler/server/ReadHoldingRegisters.js
@@ -59,7 +59,7 @@ module.exports = stampit()
                 head.writeUInt8(0x03, 0);
                 head.writeUInt8(quantity * 2, 1);
 
-                var response = Buffer.concat([head, mem.slice(byteStart * 2, byteStart * 2 + quantity * 2)]);
+                var response = Buffer.concat([head, mem.slice(byteStart, byteStart + quantity * 2)]);
 
                 this.log.debug('finished read holding register request.');
 

--- a/src/handler/server/ReadInputRegisters.js
+++ b/src/handler/server/ReadInputRegisters.js
@@ -55,8 +55,7 @@ module.exports = stampit()
                 head.writeUInt8(0x04, 0);
                 head.writeUInt8(quantity * 2, 1);
 
-                var response = Buffer.concat([head, mem.slice(byteStart * 2, byteStart * 2 + quantity * 2)]);
-
+                var response = Buffer.concat([head, mem.slice(byteStart, byteStart + quantity * 2)]);
 
                 cb(response);
 

--- a/test/modbus-client-core.test.js
+++ b/test/modbus-client-core.test.js
@@ -320,7 +320,9 @@ describe("Modbus Serial Client", function () {
            
                 assert.equal(resp.fc, 6);
                 assert.equal(resp.registerAddress, 3);
+                assert.deepEqual(resp.registerAddressRaw, Buffer.from([0x00,0x03]));
                 assert.equal(resp.registerValue, 123);
+                assert.deepEqual(resp.registerValueRaw, Buffer.from([0x00,0x7b]));
 
                 done();
 
@@ -349,6 +351,8 @@ describe("Modbus Serial Client", function () {
                 assert.equal(resp.fc, 6);
                 assert.equal(resp.registerAddress, 3);
                 assert.equal(resp.registerValue, 123);
+                assert.deepEqual(resp.registerAddressRaw, Buffer.from([0x00,0x03]));
+                assert.deepEqual(resp.registerValueRaw, Buffer.from([0x00,0x7b]));
 
                 done();
             

--- a/test/modbus-server-core.test.js
+++ b/test/modbus-server-core.test.js
@@ -267,8 +267,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read input registers request just fine.', function (done) {
 
             var core        = Core(),
-                request     = Buffer.from([0x04,0x00,0,0x00,5]),
-                exResponse  = Buffer.from([0x04,10,0x00,5,0x00,4,0x00,3,0x00,2,0x00,1]);          
+                request     = Buffer.from([0x04,0x00,0x01,0x00,0x04]),
+                exResponse  = Buffer.from([0x04,0x08,0x00,4,0x00,3,0x00,2,0x00,1]);          
             core.getInput().writeUInt16BE(0x05, 0); 
             core.getInput().writeUInt16BE(0x04, 2); 
             core.getInput().writeUInt16BE(0x03, 4); 

--- a/test/modbus-server-core.test.js
+++ b/test/modbus-server-core.test.js
@@ -202,8 +202,8 @@ describe("Modbus Server Core Tests.", function () {
         it('should handle a read holding registers request just fine.', function (done) {
 
             var core        = Core(),
-                request     = Buffer.from([0x03,0x00,0,0x00,5]),
-                exResponse  = Buffer.from([0x03,10,0x00,1,0x00,2,0x00,3,0x00,4,0x00,5]);          
+                request     = Buffer.from([0x03,0x00,0x01,0x00,0x04]),
+                exResponse  = Buffer.from([0x03,0x08,0x00,0x02,0x00,0x03,0x00,0x04,0x00,0x05]);          
             core.getHolding().writeUInt16BE(0x01, 0); 
             core.getHolding().writeUInt16BE(0x02, 2); 
             core.getHolding().writeUInt16BE(0x03, 4); 
@@ -213,9 +213,7 @@ describe("Modbus Server Core Tests.", function () {
             var resp = function (response) {
            
                 assert.equal(response.compare(exResponse), 0);
-
                 done();
-
             };
 
             core.onData(request, resp);


### PR DESCRIPTION
Some hot fixes for addressing bugs that where introduced for the `ReadHoldingRegisters` and `ReadInputRegisters` functions. I got confused with byte and word addressing and multiplied too often. The tests didn't catch that in the first place because they had the `startAddress` of `0` :-) I changed that, too.

Didn't find more problems (at least for now)

UPDATE for the sake of completeness: this fixes #87