### PR TITLE
Fixed reqId calculation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Implementation for the Serial/TCP Modbus protocol.",
   "author": "Stefan Poeter <stefan.poeter@cloud-automation.de>",
   "main": "./src/modbus.js",

--- a/src/modbus-tcp-client.js
+++ b/src/modbus-tcp-client.js
@@ -122,7 +122,7 @@ module.exports = stampit()
     var onSend = function (pdu) {
       this.log.debug('Sending pdu to the socket.')
 
-      reqId += 1
+      reqId = (reqId + 1) % 0xffff
 
       var head = Buffer.allocUnsafe(7)
 

--- a/test/modbus-tcp.test.js
+++ b/test/modbus-tcp.test.js
@@ -88,5 +88,27 @@ describe('Modbus TCP Tests.', function () {
       /* emitting a read coils request (start = 0, count = 10) */
       injectedSocket.emit('data', Buffer.from([0x01, 0x02, 0x55, 0x01]))
     })
+
+    it('should send more than 2^16 msgs just fine', function () {
+      var ModbusTcpClient = require('../src/modbus-tcp-client.js')
+      var injectedSocket = {
+        write: function () {},
+        connect: function () {},
+        on: function () {}
+      }
+
+      var client = stampit()
+        .compose(StateMachine)
+        .compose(Logger)
+        .compose(ModbusTcpClient)({
+          injectedSocket: injectedSocket
+        })
+
+      client.connect()
+
+      for (let i = 0; i < 0x10000; i++) {
+        client.emit('send', Buffer.allocUnsafe(5))
+      }
+    })
   })
 })


### PR DESCRIPTION
Previously the reqId was incremented without modulo and could exceed the
value of 0xffff which would eventually throw an `out of range` error
when executing `Buffer.writeUInt16BE`.

Now, the reqId is incremented with a modulus on 0xffff and thus should
always fit into the word without and error. A test was added to verify
(and fix) the behavior.