### PR TITLE
Sanity checks on response header in tcp client

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Implementation for the Serial/TCP Modbus protocol.",
   "author": "Stefan Poeter <stefan.poeter@cloud-automation.de>",
   "main": "./src/modbus.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "devDependencies": {
     "mocha": "^3.0.2",
-    "sinon": "1.5.0",
+    "sinon": "^1.5.0",
     "standard": "^8.5.0"
   },
   "scripts": {

--- a/src/handler/client/ReadCoils.js
+++ b/src/handler/client/ReadCoils.js
@@ -23,7 +23,7 @@ module.exports = Stampit()
       }
 
       if (fc !== 1) {
-        request.defer.reject()
+        request.defer.reject(new Error('received unexpected function code'))
         return
       }
 

--- a/src/handler/client/ReadDiscreteInputs.js
+++ b/src/handler/client/ReadDiscreteInputs.js
@@ -23,7 +23,7 @@ module.exports = Stampit()
       }
 
       if (fc !== 2) {
-        request.defer.reject()
+        request.defer.reject(new Error('received unexpected function code'))
         return
       }
 

--- a/src/handler/client/ReadHoldingRegisters.js
+++ b/src/handler/client/ReadHoldingRegisters.js
@@ -23,7 +23,7 @@ module.exports = Stampit()
       }
 
       if (fc !== 3) {
-        request.defer.reject()
+        request.defer.reject(new Error('received unexpected function code'))
         return
       }
 

--- a/src/handler/client/ReadInputRegisters.js
+++ b/src/handler/client/ReadInputRegisters.js
@@ -23,7 +23,7 @@ module.exports = Stampit()
       }
 
       if (fc !== 4) {
-        request.defer.reject()
+        request.defer.reject(new Error('received unexpected function code'))
         return
       }
 

--- a/src/handler/client/WriteMultipleCoils.js
+++ b/src/handler/client/WriteMultipleCoils.js
@@ -23,7 +23,7 @@ module.exports = stampit()
       }
 
       if (fc !== 15) {
-        request.defer.reject()
+        request.defer.reject(new Error('received unexpected function code'))
         return
       }
 

--- a/src/handler/client/WriteMultipleRegisters.js
+++ b/src/handler/client/WriteMultipleRegisters.js
@@ -23,7 +23,7 @@ module.exports = stampit()
       }
 
       if (fc !== 16) {
-        request.defer.reject()
+        request.defer.reject(new Error('received unexpected function code'))
         return
       }
 

--- a/src/handler/client/WriteSingleCoil.js
+++ b/src/handler/client/WriteSingleCoil.js
@@ -23,7 +23,7 @@ module.exports = Stampit()
       }
 
       if (fc !== 5) {
-        request.defer.reject()
+        request.defer.reject(new Error('received unexpected function code'))
         return
       }
 

--- a/src/handler/client/WriteSingleRegister.js
+++ b/src/handler/client/WriteSingleRegister.js
@@ -25,7 +25,7 @@ module.exports = Stampit()
       }
 
       if (fc !== 6) {
-        request.defer.reject()
+        request.defer.reject(new Error('received unexpected function code'))
         return
       }
 

--- a/src/modbus-tcp-client.js
+++ b/src/modbus-tcp-client.js
@@ -88,10 +88,26 @@ module.exports = stampit()
 
         var id = buffer.readUInt16BE(0)
         var len = buffer.readUInt16BE(4)
+        var protocolId = buffer.readUInt16BE(2)
+
+        if (protocolId !== 0x0000) {
+          this.log.debug('current mbap contains invalid protocol id.')
+          this.setState('error')
+          console.log(protocolId)
+          this.emit('error', new Error('Socket out of sync, received invalid protocol id'))
+          return
+        }
 
         if (id === trashRequestId) {
           this.log.debug('current mbap contains trashed request id.')
 
+          return
+        }
+
+        if (id !== currentRequestId) {
+          this.log.debug('current mbap contains invalid request id.')
+          this.setState('error')
+          this.emit('error', new Error('Socket out of sync, received invalid request id'))
           return
         }
 


### PR DESCRIPTION
Until now, the only packet validation by the TCP Client was checking the
return function code. However, if an invalid function code is returned,
only the command promise is rejected but no consequences for the socket
are being made.
In this commit, I added sanity checks on the returned modbus header,
meaning that the expected requestId as well as the protocolVersion
(0x0000) are validated on every packet. If either of these is invalid,
an error is thrown and the socket is destroyed immediately.

Bonus: added error messages to promise rejections if function code is invalid