### PR TITLE
Remove trashRequestId behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "description": "Implementation for the Serial/TCP Modbus protocol.",
   "author": "Stefan Poeter <stefan.poeter@cloud-automation.de>",
   "main": "./src/modbus.js",

--- a/src/modbus-client-core.js
+++ b/src/modbus-client-core.js
@@ -48,7 +48,6 @@ module.exports = stampit()
 
       currentRequest.timeout = setTimeout(function () {
         currentRequest.defer.reject({ err: 'timeout' })
-        this.emit('trashCurrentRequest')
 
         this.logError('Request timed out.')
 

--- a/src/modbus-client-core.js
+++ b/src/modbus-client-core.js
@@ -48,11 +48,11 @@ module.exports = stampit()
 
       currentRequest.timeout = setTimeout(function () {
         currentRequest.defer.reject({ err: 'timeout' })
+        currentRequest = undefined
 
         this.logError('Request timed out.')
 
         this.setState('error')
-      //                this.setState('ready')
       }.bind(this), this.timeout)
 
       this.setState('waiting')

--- a/src/modbus-tcp-client.js
+++ b/src/modbus-tcp-client.js
@@ -8,7 +8,6 @@ module.exports = stampit()
     var currentRequestId = reqId
     var closedOnPurpose = false
     var reconnect = false
-    var trashRequestId
     var buffer = Buffer.alloc(0)
     var socket
     var closed = true
@@ -25,13 +24,14 @@ module.exports = stampit()
 
       this.on('send', onSend)
       this.on('newState_error', onError)
-      this.on('trashCurrentRequest', onTrashCurrentRequest)
 
       this.on('stateChanged', this.log.debug)
     }.bind(this)
 
     var connect = function () {
       this.setState('connect')
+
+      buffer = Buffer.alloc(0)
 
       if (!socket) {
         /* for testing you are able to inject a mocking object
@@ -93,14 +93,7 @@ module.exports = stampit()
         if (protocolId !== 0x0000) {
           this.log.debug('current mbap contains invalid protocol id.')
           this.setState('error')
-          console.log(protocolId)
           this.emit('error', new Error('Socket out of sync, received invalid protocol id'))
-          return
-        }
-
-        if (id === trashRequestId) {
-          this.log.debug('current mbap contains trashed request id.')
-
           return
         }
 
@@ -156,15 +149,8 @@ module.exports = stampit()
       socket.write(pkt)
     }.bind(this)
 
-    var onTrashCurrentRequest = function () {
-      trashRequestId = currentRequestId
-    }
-
     this.connect = function () {
-      this.setState('connect')
-
       connect()
-
       return this
     }
 

--- a/test/modbus-tcp.test.js
+++ b/test/modbus-tcp.test.js
@@ -61,6 +61,7 @@ describe('Modbus TCP Tests.', function () {
 
       /* dummy method */
       injectedSocket.connect = function () { }
+      injectedSocket.destroy = function () { }
 
       /* create the client by composing
        * logger, state machine and the tcp client,
@@ -82,6 +83,10 @@ describe('Modbus TCP Tests.', function () {
       client.on('data', function (data) {
         assert.equal(data.compare(exResponse), 0)
         done()
+      })
+
+      client.on('error', function (err) {
+        assert.fail(err)
       })
 
       /* Send header data */


### PR DESCRIPTION
The trashRequestId Feature was never fully implemented. It is now
replaced by checking for consistent modbus headers and a complete input
buffer reinitialization on reconnect.