### PR TITLE
Update modbus-tcp-client.js

### DIFF
--- a/src/modbus-tcp-client.js
+++ b/src/modbus-tcp-client.js
@@ -69,6 +69,7 @@ module.exports = stampit()
           connect()
         }, this.reconnectTimeout || 0)
       }
+      closedOnPurpose = false
     }.bind(this)
 
     var onSocketError = function (err) {


### PR DESCRIPTION
closedOnPurpose is not reset to its initial state, so autoReconnect functionality is lost when you manually close and connect back the same client.
Adding this line fix that issue