### PR TITLE
Tcp server

### DIFF
--- a/test/read-coils.test.js
+++ b/test/read-coils.test.js
@@ -34,6 +34,15 @@ describe('ReadCoils Tests.', function () {
 
       assert.deepEqual(expected, buffer)
     })
+    it('should return an individual coil if requested', function () {
+      let requestBody = ModbusRequestBody.fromBuffer(Buffer.from([0x01, 0x00, 0x00, 0x00, 0x01]))
+      let coils = Buffer.from([0xff, 0xff])
+      let response = ReadCoilsResponse.fromRequest(requestBody, coils)
+      let buffer = response.createPayload()
+      let expected = Buffer.from([0x01, 0x01, 0x01])
+
+      assert.deepEqual(expected, buffer)
+    })
     it('should return null on not enough buffer data', function () {
       let buffer = Buffer.from([0x01])
       let message = ReadCoilsResponse.fromBuffer(buffer)

--- a/test/tcp-server-response-handler.test.js
+++ b/test/tcp-server-response-handler.test.js
@@ -38,6 +38,6 @@ describe('Modbus/TCP Server Response Handler Tests', function () {
       0x01        // coils
     ])
 
-    assert(payload = responseBuffer)
+    assert(payload.equals(responseBuffer))
   })
 })


### PR DESCRIPTION
Modified read-coils to cope with requests for less than a whole byte. The remaining bits are padded with zeros. Let me know if this is going down the wrong path.