### PR TITLE
add: pass unitId for daisy-chained devices

### DIFF
--- a/examples/serial/ReadHoldingRegister.js
+++ b/examples/serial/ReadHoldingRegister.js
@@ -1,7 +1,7 @@
 'use strict'
 
 var modbus = require('../..')
-var client = modbus.client.serial.complete({ 'portName': process.argv[2], 'baudRate': process.argv[3] })
+var client = modbus.client.serial.complete({ 'portName': process.argv[2], 'baudRate': parseInt(process.argv[3]) })
 
 client.on('connect', function () {
   client.readHoldingRegisters(process.argv[4], process.argv[5]).then(function (resp) {

--- a/src/modbus-serial-client.js
+++ b/src/modbus-serial-client.js
@@ -33,6 +33,10 @@ module.exports = stampit()
         this.parity = 'none'
       }
 
+      if (!this.unitId) {
+        this.unitId = 0x01
+      }
+
       // TODO: flowControl - ['xon', 'xoff', 'xany', 'rtscts']
 
       // TODO: settings - ['brk', 'cts', 'dtr', 'dts', 'rts']
@@ -73,7 +77,7 @@ module.exports = stampit()
     }.bind(this)
 
     var onSend = function (pdu) {
-      var base = Buffer.from([0x01])
+      var base = Buffer.from([this.unitId])
       var buf = Buffer.concat([base, pdu])
       var crc16 = crc.crc16modbus(buf)
       var crcBuf = Buffer.allocUnsafe(2)


### PR DESCRIPTION
Added ability to pass unitId to serial interfaces to support polling [daisy-chained devices.](http://www.metersusa.com/Accuenergy/Software/Commhookup.htm)

I see no serial tests, none added, fyi