### PR TITLE
Corrected handling of multiple incoming responses

### DIFF
--- a/src/modbus-client.js
+++ b/src/modbus-client.js
@@ -46,13 +46,10 @@ class ModbusClient {
         return
       }
       
-      /* unitId mis-match */
+      /* process the response in the request handler if unitId matches*/
       if (this._unitId != response.unitId) {
-        return
+        this._requestHandler.handle(response)
       }
-
-      /* process the response in the request handler */
-      this._requestHandler.handle(response)
     } while (1)
   }
 


### PR DESCRIPTION
Multiple responses were getting dropped if the first one didn't match the unitId