### PR TITLE
Fix skipping of responses on unitId mismatch

### DIFF
--- a/src/modbus-client.js
+++ b/src/modbus-client.js
@@ -46,13 +46,10 @@ class ModbusClient {
         return
       }
       
-      /* unitId mis-match */
-      if (this._unitId != response.unitId) {
-        return
+      /* process the response in the request handler if unitId is a match */
+      if (this._unitId == response.unitId) {
+        this._requestHandler.handle(response)
       }
-
-      /* process the response in the request handler */
-      this._requestHandler.handle(response)
     } while (1)
   }
 


### PR DESCRIPTION
The unitId filter was dropping out of the loop completely thus missing responses that were valid but behind responses that were not.