### PR TITLE
 Request timeout getting cleared too soon

### DIFF
--- a/src/client-request-handler.js
+++ b/src/client-request-handler.js
@@ -160,7 +160,6 @@ class ModbusClientRequestHandler {
 
     this._socket.write(payload, function (err, result) {
       debug('request fully flushed, ( error:', err, ')', result)
-      this._currentRequest.done()
     }.bind(this))
   }
 }


### PR DESCRIPTION
The request timeout was getting cleared as soon as the request was written to the socket rather than waiting until the request succeeds or times out.