### PR TITLE
Fixes #199 – RTU CRC failed because of typo bodyCount => byteCount

### DIFF
--- a/src/rtu-response.js
+++ b/src/rtu-response.js
@@ -19,7 +19,7 @@ class ModbusRTUResponse {
 
     let crc
     try {
-      crc = buffer.readUInt16LE(1 + body.bodyCount)
+      crc = buffer.readUInt16LE(1 + body.byteCount)
     } catch (e) {
       debug('If NoSuchIndexException, it is probably serial and not all data has arrived')
       return null

--- a/test/rtu-client-response-handler.test.js
+++ b/test/rtu-client-response-handler.test.js
@@ -20,7 +20,7 @@ describe('Modbus/RTU Client Response Tests', function () {
       0x02,       // byte count
       0xdd,       // coils
       0x00,
-      0x00, 0x00 // crc
+      0xCD, 0xAB // crc
     ])
 
     handler.handleData(responseBuffer)
@@ -30,7 +30,7 @@ describe('Modbus/RTU Client Response Tests', function () {
     assert.ok(response !== null)
     assert.equal(1, response.address)
     assert.equal(1, response.body.fc)
-    assert.equal(257, response.crc)
+    assert.equal(0xABCD, response.crc)
     assert.equal(7, response.byteCount)
 
     assert.equal(1, response.body.fc)


### PR DESCRIPTION
When using Node 10, the expected CRC value in the test case itself also did not match the actual value.
I also changed the value to be able to detect byte swaps.

This wasn't caught before because:
1. Node 8's implementation of `Buffer.prototype.readUInt16BE` returns `0` when `NaN` is passed.  See https://github.com/Cloud-Automation/node-modbus/issues/199#issuecomment-401561941. This is fixed in later versions of Node (I was using Node 10), but in Travis, only up to 8 is being tested.
2. The test expectation was all zeroes, matching the return value when `NaN` was passed when using Node 8.