### PR TITLE
bugfix: exception response msb bit not being set to 1

### DIFF
--- a/src/response/exception.js
+++ b/src/response/exception.js
@@ -57,7 +57,7 @@ class ExceptionResponseBody extends ModbusResponseBody {
 
   createPayload () {
     let payload = Buffer.alloc(2)
-    payload.writeUInt8(this._fc, 0)
+    payload.writeUInt8(this._fc | 0x80, 0)
     payload.writeUInt8(this._code, 1)
     return payload
   }

--- a/test/response-body.test.js
+++ b/test/response-body.test.js
@@ -3,6 +3,7 @@
 /* global describe, it */
 
 let assert = require('assert')
+const ExceptionResponseBody = require('../src/response/exception.js')
 let ResponseBody = require('../src/response/response-body.js')
 let ReadCoilsResponseBody = require('../src/response/read-coils.js')
 
@@ -53,6 +54,12 @@ describe('Modbus Response Tests.', function () {
       let response = ReadCoilsResponseBody.fromBuffer(buffer)
 
       assert.ok(response === null)
+    })
+  })
+  describe('Exception Responses', function () {
+    it('should set the MSB to 1 on the function field', function () {
+      const response = new ExceptionResponseBody(0x01, 0x04)
+      assert.deepEqual(response.createPayload(), Buffer.from([0x81, 0x04]))
     })
   })
 })


### PR DESCRIPTION
As per the spec:

> In an exception response, the server sets the MSB of the function code to 1. This makes the function code value in an exception response exactly 80 hexadecimal higher than the value would be for a normal response.