### PR TITLE
Fix Server Event Listener Overload Mismatch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "4.0.3",
+  "version": "4.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "4.0.4",
+  "version": "4.0.5",
   "description": "Implementation for the Serial/TCP Modbus protocol.",
   "author": "Stefan Poeter <stefan.poeter@cloud-automation.de>",
   "main": "./dist/modbus.js",

--- a/src/modbus-server.ts
+++ b/src/modbus-server.ts
@@ -91,7 +91,6 @@ export default class ModbusServer extends EventEmitter {
   public on (event: 'writeMultipleRegisters', listener: (holdingRegisters: Buffer) => void): this
   public on (event: 'postWriteMultipleRegisters', listener: (holdingRegisters: Buffer) => void): this
   public on (event: 'postWriteMultipleRegisters', listener: (request: AbstractRequest, cb: BufferCB) => void): this
-  public on (event: 'connection', listener: (socket: Socket) => void): this
   public on (event: string | symbol, listener: (...args: any[]) => void): this {
     return super.on(event, listener)
   }

--- a/src/modbus-tcp-server.ts
+++ b/src/modbus-tcp-server.ts
@@ -8,7 +8,7 @@ import ModbusTCPResponse from './tcp-response.js'
 export default class ModbusTCPServer extends ModbusServer {
   public _server: Server | ModbusServer
 
-  constructor (server: Server | ModbusServer, options?: Partial<IModbusServerOptions>) {
+  constructor (server: Server, options?: Partial<IModbusServerOptions>) {
     super(options)
     this._server = server
 


### PR DESCRIPTION
The modbus server does not accept an event
of 'connection' and respond with a net socket.

Fixes #269