### PR TITLE
TCP Client: Reject currentRequest onClose to handle ECONNRESET

### DIFF
--- a/src/client-request-handler.ts
+++ b/src/client-request-handler.ts
@@ -186,6 +186,10 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
 
   protected _onClose () {
     this._state = 'offline'
+    this._currentRequest && this._currentRequest.reject(new UserRequestError({
+      err: OFFLINE,
+      message: 'connection to modbus server closed'
+    }))
     this._clearAllRequests()
   }
 

--- a/test/tcp-client.test.js
+++ b/test/tcp-client.test.js
@@ -122,6 +122,22 @@ describe('TCP Client Tests.', function () {
           done()
         })
     })
+    it('should handle a valid request with read ECONNRESET', function (done) {
+      socket.write  = function() {
+        // Socket receives a read ECONNRESET, the socket is closed and no further data is received
+        socket.emit('close');
+      }
+      const client = new Modbus.client.TCP(socket, 2, 100) // unit id = 2, timeout = 100ms
+      socket.emit('connect')
+      
+      client.readCoils(10, 11)
+        .then(function (resp) {
+          assert.ok(false)
+        }).catch(function (e) {
+          assert.equal('Offline', e.err)
+          done()
+        })
+    })
     it('should handle a valid request while offline', function (done) {
       const client = new Modbus.client.TCP(socket)
 


### PR DESCRIPTION
Always reject the current request when the socket closes to prevents unresolved promises on ECONNRESET

Fixes #305 