### PR TITLE
Add RTU slave address filtering.

### DIFF
--- a/src/modbus-rtu-server.ts
+++ b/src/modbus-rtu-server.ts
@@ -16,7 +16,8 @@ export default class ModbusRTUServer extends ModbusServer {
 
     const fromBuffer = ModbusRTURequest.fromBuffer
     const fromRequest = ModbusRTUResponse.fromRequest as any
-    const client = new ModbusServerClient(this, socket, fromBuffer, fromRequest)
+    const slaveId = options && typeof options.slaveId !== 'undefined' ? options.slaveId : -1
+    const client = new ModbusServerClient(this, socket, fromBuffer, fromRequest, slaveId)
     this.emit('connection', client)
   }
 }

--- a/src/modbus-server-client.ts
+++ b/src/modbus-server-client.ts
@@ -20,12 +20,13 @@ export default class ModbusServerClient<
     server: ModbusServer,
     socket: S,
     fromBufferMethod: ReqFromBufferMethod,
-    fromRequestMethod: ResFromRequestMethod
+    fromRequestMethod: ResFromRequestMethod,
+    slaveId: number = -1
   ) {
     this._server = server
     this._socket = socket
 
-    this._requestHandler = new ModbusServerRequestHandler(fromBufferMethod)
+    this._requestHandler = new ModbusServerRequestHandler(fromBufferMethod, slaveId)
     this._responseHandler = new ModbusServerResponseHandler(this._server, fromRequestMethod)
 
     this._socket.on('data', this._onData.bind(this))

--- a/src/modbus-server-request-handler.ts
+++ b/src/modbus-server-request-handler.ts
@@ -7,11 +7,13 @@ export default class ModbusServerRequestHandler<FB extends ModbusAbstractRequest
   public _fromBuffer: FB
   public _requests: ModbusAbstractRequest[]
   public _buffer: Buffer
+  public _slaveId: number
 
-  constructor (fromBufferMethod: FB) {
+  constructor (fromBufferMethod: FB, slaveId: number = -1) {
     this._fromBuffer = fromBufferMethod
     this._requests = []
     this._buffer = Buffer.alloc(0)
+    this._slaveId = slaveId
   }
 
   public shift () {
@@ -33,6 +35,8 @@ export default class ModbusServerRequestHandler<FB extends ModbusAbstractRequest
       if (request instanceof ModbusRTURequest && request.corrupted) {
         const corruptDataDump = this._buffer.slice(0, request.byteCount).toString('hex')
         debug(`request message was corrupt: ${corruptDataDump}`)
+      } else if (request instanceof ModbusRTURequest && this._slaveId !== -1 && request.slaveId !== this._slaveId) {
+        debug('request message not for this address')
       } else {
         this._requests.unshift(request)
       }

--- a/src/modbus-server.ts
+++ b/src/modbus-server.ts
@@ -11,13 +11,15 @@ export interface IModbusServerOptions {
   discrete: Buffer
   holding: Buffer
   input: Buffer
+  slaveId: number
 }
 
 const DEFAULT_MODBUS_SERVER_OPTIONS: IModbusServerOptions = {
   coils: Buffer.alloc(1024),
   discrete: Buffer.alloc(1024),
   holding: Buffer.alloc(1024),
-  input: Buffer.alloc(1024)
+  input: Buffer.alloc(1024),
+  slaveId: -1
 }
 
 export type BufferCB = (buffer: Buffer) => void


### PR DESCRIPTION
Add optional slaveId parameter to ModbusRTUServer constructor. SlaveId is checked when parsing requests.