### PR TITLE
Implement providing Request in UserRequestError.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "4.0.8",
+  "version": "4.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "4.0.9",
+  "version": "4.0.10",
   "description": "Implementation for the Serial/TCP Modbus protocol.",
   "author": "Stefan Poeter <stefan.poeter@cloud-automation.de>",
   "main": "./dist/modbus.js",

--- a/src/client-request-handler.ts
+++ b/src/client-request-handler.ts
@@ -91,7 +91,8 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
       /* clear all request, client must be reset */
       userRequest.reject(new UserRequestError({
         err: OUT_OF_SYNC,
-        message: 'request fc and response fc does not match.'
+        message: 'request fc and response fc does not match.',
+        request
       }))
       this._clearAllRequests()
       return
@@ -103,7 +104,8 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
       userRequest.reject(new UserRequestError({
         err: MODBUS_EXCEPTION,
         message: `A Modbus Exception Occurred - See Response Body`,
-        response
+        response,
+        request
       }))
       this._clearCurrentRequest()
       this._flush()
@@ -152,7 +154,7 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
   /**
    * Reject current request with a custom error
    */
-  public customErrorRequest (err: UserRequestError<any>) {
+  public customErrorRequest (err: UserRequestError<any, any>) {
     if (this._currentRequest) {
       this._currentRequest.reject(err)
     }

--- a/src/client-request-handler.ts
+++ b/src/client-request-handler.ts
@@ -129,7 +129,8 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
     if (this._currentRequest) {
       this._currentRequest.reject(new UserRequestError({
         err: MANUALLY_CLEARED,
-        message: 'the request was manually cleared'
+        message: 'the request was manually cleared',
+        request: this._currentRequest.request
       }))
       this._flush()
     }
@@ -176,7 +177,8 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
       if (req) {
         req.reject(new UserRequestError({
           err: OUT_OF_SYNC,
-          message: 'rejecting because of earlier OutOfSync error'
+          message: 'rejecting because of earlier OutOfSync error',
+          request: req.request
         }))
       }
     }
@@ -190,7 +192,8 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
     this._state = 'offline'
     this._currentRequest && this._currentRequest.reject(new UserRequestError({
       err: OFFLINE,
-      message: 'connection to modbus server closed'
+      message: 'connection to modbus server closed',
+      request: this._currentRequest.request
     }))
     this._clearAllRequests()
   }
@@ -214,7 +217,8 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
       debug('rejecting request immediatly, client offline')
       this._currentRequest && this._currentRequest.reject(new UserRequestError({
         err: OFFLINE,
-        message: 'no connection to modbus server'
+        message: 'no connection to modbus server',
+        request: this._currentRequest.request
       }))
       this._clearCurrentRequest()
       /* start next request */

--- a/src/client-request-handler.ts
+++ b/src/client-request-handler.ts
@@ -104,8 +104,8 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
       userRequest.reject(new UserRequestError({
         err: MODBUS_EXCEPTION,
         message: `A Modbus Exception Occurred - See Response Body`,
-        response,
-        request
+        request,
+        response
       }))
       this._clearCurrentRequest()
       this._flush()

--- a/src/modbus-client.ts
+++ b/src/modbus-client.ts
@@ -309,7 +309,7 @@ export default abstract class MBClient<S extends Stream.Duplex, Req extends Modb
   /**
    * Reject current request with a custom error
    */
-  public customErrorRequest (err: UserRequestError<any>) {
+  public customErrorRequest (err: UserRequestError<any, any>) {
     return this._requestHandler.customErrorRequest(err)
   }
 

--- a/src/modbus.ts
+++ b/src/modbus.ts
@@ -72,6 +72,8 @@ export { default as ModbusClient } from './modbus-client'
 export * from './request-response-map'
 export { default as ModbusTCPRequest } from './tcp-request'
 export { default as ModbusTCPResponse } from './tcp-response'
+export { default as ModbusRTURequest } from './rtu-request'
+export { default as ModbusRTUResponse } from './rtu-response'
 export { UserRequestError } from './user-request-error'
 export {
   default as UserRequest,

--- a/src/rtu-client-request-handler.ts
+++ b/src/rtu-client-request-handler.ts
@@ -71,7 +71,9 @@ export default class ModbusRTUClientRequestHandler extends MBClientRequestHandle
       debug('CRC does not match', response.crc, '!==', crc)
       userRequest.reject(new UserRequestError({
         err: 'crcMismatch',
-        message: 'the response payload does not match the crc'
+        message: 'the response payload does not match the crc',
+        request: userRequest.request,
+        response
       }))
       this._clearAllRequests()
       return

--- a/src/tcp-client-request-handler.ts
+++ b/src/tcp-client-request-handler.ts
@@ -81,7 +81,8 @@ export default class ModbusTCPClientRequestHandler extends MBClientRequestHandle
       /* clear all request, client must be reset */
       userRequest.reject(new UserRequestError({
         err: OUT_OF_SYNC,
-        message: 'request fc and response fc does not match.'
+        message: 'request fc and response fc does not match.',
+        request
       }))
       this._clearAllRequests()
       return
@@ -92,7 +93,8 @@ export default class ModbusTCPClientRequestHandler extends MBClientRequestHandle
       debug('server responds with wrong protocol version')
       userRequest.reject(new UserRequestError({
         err: PROTOCOL,
-        message: 'Unknown protocol version ' + response.protocol
+        message: 'Unknown protocol version ' + response.protocol,
+        request
       }))
       this._clearAllRequests()
       return

--- a/src/user-request-error.ts
+++ b/src/user-request-error.ts
@@ -16,7 +16,7 @@ export class UserRequestError<Res extends ModbusAbstractResponse, Req extends Mo
   public message: string
   public request?: Req
   public response?: Res
-  constructor ({ err, message, request, response }: IUserRequestError<Res, Req>) {
+  constructor ({ err, message, response, request }: IUserRequestError<Res, Req>) {
     this.err = err
     this.message = message
     this.request = request

--- a/src/user-request-error.ts
+++ b/src/user-request-error.ts
@@ -1,25 +1,29 @@
 import ModbusAbstractResponse from './abstract-response'
+import ModbusAbstractRequest from "./abstract-request";
 
 export type UserRequestErrorCodes = 'OutOfSync' | 'Protocol' | 'Timeout' | 'ManuallyCleared' | 'ModbusException' | 'Offline' | 'crcMismatch'
 
-export interface IUserRequestError<Res extends ModbusAbstractResponse> {
+export interface IUserRequestError<Res extends ModbusAbstractResponse, Req extends ModbusAbstractRequest> {
   err: UserRequestErrorCodes
   message: string
-  response?: Res
+  response?: Res,
+  request?: Req
 }
 
-export class UserRequestError<Res extends ModbusAbstractResponse> implements IUserRequestError<Res> {
+export class UserRequestError<Res extends ModbusAbstractResponse, Req extends ModbusAbstractRequest> implements IUserRequestError<Res, Req> {
   public err: UserRequestErrorCodes
   public message: string
   public response?: Res
-  constructor ({ err, message, response }: IUserRequestError<Res>) {
+  public request?: Req
+  constructor ({ err, message, response, request }: IUserRequestError<Res, Req>) {
     this.err = err
     this.message = message
     this.response = response
+    this.request = request
   }
 }
 
-export function isUserRequestError (x: any): x is UserRequestError<any> {
+export function isUserRequestError (x: any): x is UserRequestError<any, any> {
   if (x instanceof isUserRequestError) {
     return true
   }

--- a/src/user-request-error.ts
+++ b/src/user-request-error.ts
@@ -1,5 +1,5 @@
+import ModbusAbstractRequest from './abstract-request'
 import ModbusAbstractResponse from './abstract-response'
-import ModbusAbstractRequest from "./abstract-request";
 
 export type UserRequestErrorCodes = 'OutOfSync' | 'Protocol' | 'Timeout' | 'ManuallyCleared' | 'ModbusException' | 'Offline' | 'crcMismatch'
 
@@ -10,16 +10,17 @@ export interface IUserRequestError<Res extends ModbusAbstractResponse, Req exten
   request?: Req
 }
 
-export class UserRequestError<Res extends ModbusAbstractResponse, Req extends ModbusAbstractRequest> implements IUserRequestError<Res, Req> {
+export class UserRequestError<Res extends ModbusAbstractResponse, Req extends ModbusAbstractRequest>
+    implements IUserRequestError<Res, Req> {
   public err: UserRequestErrorCodes
   public message: string
-  public response?: Res
   public request?: Req
-  constructor ({ err, message, response, request }: IUserRequestError<Res, Req>) {
+  public response?: Res
+  constructor ({ err, message, request, response }: IUserRequestError<Res, Req>) {
     this.err = err
     this.message = message
-    this.response = response
     this.request = request
+    this.response = response
   }
 }
 

--- a/src/user-request.ts
+++ b/src/user-request.ts
@@ -64,7 +64,8 @@ export default class UserRequest<Req extends ModbusAbstractRequest = any> {
     this._timer = setTimeout(() => {
       this._reject(new UserRequestError({
         err: 'Timeout',
-        message: 'Req timed out'
+        message: 'Req timed out',
+        request: this._request
       }))
       cb()
     }, this._timeout)

--- a/src/user-request.ts
+++ b/src/user-request.ts
@@ -30,7 +30,7 @@ export default class UserRequest<Req extends ModbusAbstractRequest = any> {
   protected readonly _timeout: number
   protected readonly _promise: PromiseUserRequest<Req>
   protected _resolve!: (value: IUserRequestResolve<Req>) => void
-  protected _reject!: (err: UserRequestError<RequestToResponse<Req>>) => void
+  protected _reject!: (err: UserRequestError<RequestToResponse<Req>, Req>) => void
   protected _timer!: NodeJS.Timeout
 
   protected _metrics: UserRequestMetrics

--- a/test/rtu-client-request-handler.test.js
+++ b/test/rtu-client-request-handler.test.js
@@ -10,6 +10,7 @@ const ReadHoldingRegistersRequestBody = require('../dist/request/read-holding-re
 const ModbusRTUResponse = require('../dist/rtu-response.js').default
 const ExceptionResponse = require('../dist/response/exception.js').default
 const ModbusRTUClientRequestHandler = require('../dist/rtu-client-request-handler.js').default
+const Modbus = require('../dist/modbus.js')
 
 
 describe('Modbus/RTU Client Request Tests', function () {
@@ -83,6 +84,7 @@ describe('Modbus/RTU Client Request Tests', function () {
         }).catch(function (err) {
           // Exception type should be ModbusException not crcMismatch or any other 
           assert.equal(err.err, 'ModbusException')
+          assert.equal(err.request instanceof Modbus.ModbusRTURequest, true)
           socketMock.verify()
 
           done()
@@ -114,6 +116,7 @@ describe('Modbus/RTU Client Request Tests', function () {
         }).catch(function (err) {     
           // Exception type should be ModbusException not crcMismatch or any other 
           assert.equal(err.err, 'ModbusException')
+          assert.equal(err.request instanceof Modbus.ModbusRTURequest, true)
           socketMock.verify()
 
           done()

--- a/test/rtu-client-request-handler.test.js
+++ b/test/rtu-client-request-handler.test.js
@@ -82,7 +82,7 @@ describe('Modbus/RTU Client Request Tests', function () {
 
           done()
         }).catch(function (err) {
-          // Exception type should be ModbusException not crcMismatch or any other 
+          // Exception type should be ModbusException not crcMismatch or any other
           assert.equal(err.err, 'ModbusException')
           assert.equal(err.request instanceof Modbus.ModbusRTURequest, true)
           socketMock.verify()
@@ -100,7 +100,7 @@ describe('Modbus/RTU Client Request Tests', function () {
         0x01,       // address
         0x83,       // fc
         0x02,       // error code
-        0xc0, 0xf1  // crc              
+        0xc0, 0xf1  // crc
       ])
       const rtuResponse = ModbusRTUResponse.fromBuffer(responseBuffer)
 
@@ -109,12 +109,12 @@ describe('Modbus/RTU Client Request Tests', function () {
       socketMock.expects('write').once()
 
       handler.register(request)
-        .then(function (resp) {          
+        .then(function (resp) {
           assert.ok(false)
 
           done()
-        }).catch(function (err) {     
-          // Exception type should be ModbusException not crcMismatch or any other 
+        }).catch(function (err) {
+          // Exception type should be ModbusException not crcMismatch or any other
           assert.equal(err.err, 'ModbusException')
           assert.equal(err.request instanceof Modbus.ModbusRTURequest, true)
           socketMock.verify()
@@ -124,7 +124,7 @@ describe('Modbus/RTU Client Request Tests', function () {
 
       handler.handle(rtuResponse)
       // rtuResponse.crc
-      
+
     })
   })
 })

--- a/test/rtu-client-request-handler.test.js
+++ b/test/rtu-client-request-handler.test.js
@@ -85,6 +85,7 @@ describe('Modbus/RTU Client Request Tests', function () {
           // Exception type should be ModbusException not crcMismatch or any other
           assert.equal(err.err, 'ModbusException')
           assert.equal(err.request instanceof Modbus.ModbusRTURequest, true)
+          assert.equal(err.request.body, request)
           socketMock.verify()
 
           done()
@@ -117,6 +118,7 @@ describe('Modbus/RTU Client Request Tests', function () {
           // Exception type should be ModbusException not crcMismatch or any other
           assert.equal(err.err, 'ModbusException')
           assert.equal(err.request instanceof Modbus.ModbusRTURequest, true)
+          assert.equal(err.request.body, request)
           socketMock.verify()
 
           done()

--- a/test/tcp-client.test.js
+++ b/test/tcp-client.test.js
@@ -129,7 +129,7 @@ describe('TCP Client Tests.', function () {
       }
       const client = new Modbus.client.TCP(socket, 2, 100) // unit id = 2, timeout = 100ms
       socket.emit('connect')
-      
+
       client.readCoils(10, 11)
         .then(function (resp) {
           assert.ok(false)

--- a/test/tcp-client.test.js
+++ b/test/tcp-client.test.js
@@ -296,6 +296,7 @@ describe('TCP Client Tests.', function () {
           assert.equal(Modbus.errors.isInternalException(e), false)
           assert.equal(Modbus.errors.isUserRequestError(e), true)
           assert.equal('OutOfSync', e.err)
+          assert.equal(e.request instanceof Modbus.ModbusTCPRequest, true)
           socketMock.verify()
           done()
         })
@@ -324,6 +325,7 @@ describe('TCP Client Tests.', function () {
           done()
         }).catch(function (e) {
           assert.equal('Protocol', e.err)
+          assert.equal(e.request instanceof Modbus.ModbusTCPRequest, true)
           socketMock.verify()
           done()
         })


### PR DESCRIPTION
When an `UserRequestError` is thrown, provide the original `ModbusAbstractRequest` in the error body.

This will allow running createPayload in the main application for debugging purposes.

Currently the only way to get the generated payload is by enabling debug, which can only be done using environment variable:

```
DEBUG=client-request-handler
```

but this will produce a lot of spam of all modbus communication, while I only want to get the payload of only the request I am testing.

Current location where debug for payload is provided:

https://github.com/Cloud-Automation/node-modbus/blob/a7e0d6a247a9771889919d89a0ab8b4c0192ced7/src/client-request-handler.ts#L225

Fixes https://github.com/Cloud-Automation/node-modbus/issues/256