### PR TITLE
Fix write-single-coil.ts incorrect processing of true value #338

### DIFF
--- a/src/response/write-single-coil.ts
+++ b/src/response/write-single-coil.ts
@@ -53,8 +53,12 @@ export default class WriteSingleCoilResponseBody extends ModbusWriteResponseBody
   constructor (address: number, value: 0 | 0xff00 | boolean) {
     super(FC.WRITE_SINGLE_COIL)
     this._address = address
-
-    this._value = value === 0xFF00 ? 0xFF00 : 0x0000
+    
+    if (value === true || value === 0xFF00) {
+        this._value = 0xFF00
+    } else {
+        this._value = 0x0000
+    }
   }
 
   public createPayload () {


### PR DESCRIPTION
Fix for the #338
The WriteSingleCoilResponseBody constructor declares that it can handle `boolen` but it can not do that. So I have addled  boolean handling into the function.

Manually tested for both `true` and `false` input.

I have tried to make commit a oneliner like so 
`this._value = value === ( true || 0xFF00 ? 0xFF00 : 0x0000)`
But did not find it readable enough and did not like being dependent on parenthesis

I have not added any automated test for this fix because unfortunately I'm unable to properly run `npm install` neither on my mac nor on ubuntu, the `SerialPort` package fails to install and I have further issues with mocha (I did try to install that globally along with sinon).

Hope that helps!
