### PR TITLE
Improved UserRequestError message if error is ModbusException.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "4.0.10",
+  "version": "4.0.11",
   "description": "Implementation for the Serial/TCP Modbus protocol.",
   "author": "Stefan Poeter <stefan.poeter@cloud-automation.de>",
   "main": "./dist/modbus.js",

--- a/src/client-request-handler.ts
+++ b/src/client-request-handler.ts
@@ -103,7 +103,7 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
       debug('response is a exception')
       userRequest.reject(new UserRequestError({
         err: MODBUS_EXCEPTION,
-        message: `ModbusException: ${response.body.message} (${response.body.code})`,
+        message: `ModbusException: ${response.body.message} (Code ${response.body.code}) (Device Address ${response.address})`,
         request,
         response
       }))

--- a/src/client-request-handler.ts
+++ b/src/client-request-handler.ts
@@ -103,7 +103,7 @@ export default abstract class MBClientRequestHandler<S extends Stream.Duplex, Re
       debug('response is a exception')
       userRequest.reject(new UserRequestError({
         err: MODBUS_EXCEPTION,
-        message: `A Modbus Exception Occurred - See Response Body`,
+        message: `ModbusException: ${response.body.message} (${response.body.code})`,
         request,
         response
       }))


### PR DESCRIPTION
If a UserRequestError is thrown because of a Modbus Exception, I added an improved message to the error.

Before it would just print out:

```
A Modbus Exception Occurred - See Response Body
```

`console.error(..)` would print out the `response.body.code` and using that could be seen what the issue is, but when I use the error in conjunction with Sentry error reporting, it won't provide me those values.

Now the error message will be something like:

```
ModbusException: ILLEGAL DATA ADDRESS (Code 2) (Device Address 1)
```

@stefanpoeter Could you take a look?