### PR TITLE
Fix invalid write coil response parsing, causing writing true always producing CRC error

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jsmodbus",
-  "version": "4.0.11",
+  "version": "4.0.12",
   "description": "Implementation for the Serial/TCP Modbus protocol.",
   "author": "Stefan Poeter <stefan.poeter@cloud-automation.de>",
   "main": "./dist/modbus.js",

--- a/src/response/write-single-coil.ts
+++ b/src/response/write-single-coil.ts
@@ -54,7 +54,7 @@ export default class WriteSingleCoilResponseBody extends ModbusWriteResponseBody
     super(FC.WRITE_SINGLE_COIL)
     this._address = address
 
-    this._value = value === 0xFF00 ? 0xFF00 : 0x0000
+    this._value = (value === 0xFF00 || value === true) ? 0xFF00 : 0x0000
   }
 
   public createPayload () {

--- a/test/write-single-coil.test.js
+++ b/test/write-single-coil.test.js
@@ -4,15 +4,45 @@
 
 const assert = require('assert')
 const WriteSingleCoilRequest = require('../dist/request/write-single-coil.js').default
+const WriteSingleCoilResponseBody = require("../dist/response/write-single-coil.js").default;
 
 describe('WriteSingleCoil Tests.', function () {
   describe('WriteSingleCoil Response', function () {
-    it('should create a buffer from a write single coil message', function () {
+    it('should create a buffer from a write single coil message, true test', function () {
       const request = new WriteSingleCoilRequest(10, true)
       const buffer = request.createPayload()
       const expected = Buffer.from([0x05, 0x00, 0x0a, 0xff, 0x00])
 
       assert.deepEqual(expected, buffer)
+    })
+    it('should create a buffer from a write single coil message, false false', function () {
+      const request = new WriteSingleCoilRequest(10, false)
+      const buffer = request.createPayload()
+      const expected = Buffer.from([0x05, 0x00, 0x0a, 0x00, 0x00])
+
+      assert.deepEqual(expected, buffer)
+    })
+    it('should provide a response that equals the write request, true test', function () {
+      const expected = Buffer.from([0x05, 0x00, 0x0a, 0xff, 0x00])
+
+      const request = new WriteSingleCoilRequest(10, true)
+      const requestBuffer = request.createPayload()
+      const response = WriteSingleCoilResponseBody.fromBuffer(requestBuffer)
+      const responseBuffer = response.createPayload()
+
+      assert.strictEqual(true, response.value)
+      assert.deepEqual(expected, responseBuffer)
+    })
+    it('should provide a response that equals the write request, false test', function () {
+      const expected = Buffer.from([0x05, 0x00, 0x0a, 0x00, 0x00])
+
+      const request = new WriteSingleCoilRequest(10, false)
+      const requestBuffer = request.createPayload()
+      const response = WriteSingleCoilResponseBody.fromBuffer(requestBuffer)
+      const responseBuffer = response.createPayload()
+
+      assert.strictEqual(false, response.value)
+      assert.deepEqual(expected, responseBuffer)
     })
     it('should create a message from a buffer', function () {
       const buffer = Buffer.from([0x05, 0x00, 0x0a, 0xff, 0x00])

--- a/test/write-single-coil.test.js
+++ b/test/write-single-coil.test.js
@@ -15,7 +15,7 @@ describe('WriteSingleCoil Tests.', function () {
 
       assert.deepEqual(expected, buffer)
     })
-    it('should create a buffer from a write single coil message, false false', function () {
+    it('should create a buffer from a write single coil message, false test', function () {
       const request = new WriteSingleCoilRequest(10, false)
       const buffer = request.createPayload()
       const expected = Buffer.from([0x05, 0x00, 0x0a, 0x00, 0x00])


### PR DESCRIPTION
The parsing of the write single coil response is not checking against `=== true`. When the response is instantiated using the `fromBuffer` static function, which passes `value` as boolean, it will always cause the response to be parsed as `false`.

This causes the CRC check to fail since the `createPayload` will produce something different from the actual response of the client device.

This PR will add a check for `=== true` in the constructor and added tests to prevent this from becoming an issue in the future.

@stefanpoeter Could you check my changes?